### PR TITLE
A couple patches for hard errors from fresh setup

### DIFF
--- a/socket/src/managers/accounts.ts
+++ b/socket/src/managers/accounts.ts
@@ -18,7 +18,7 @@ class Accounts {
   async getOrCreate(identifiers: Record<string, string>): Promise<PrismaAccount> {
     const where: Record<string, string> = {};
     for (const key in identifiers) {
-      if (key === 'ip') {
+      if (key === 'ip' || key === 'license' || key === 'license2' || key === 'discord') {
         continue;
       }
       where[`identifier_${key}`] = identifiers[key];

--- a/socket/src/managers/characters.ts
+++ b/socket/src/managers/characters.ts
@@ -28,6 +28,7 @@ class Characters {
   ): Promise<PrismaCharacterWithFace | null> {
     // @ts-ignore
     characterData.dateOfBirth = new Date(characterData.dateOfBirth);
+    // @ts-ignore
     const character = await this.prisma.characters.create({ data: { ...characterData, accountId: ownerId } });
     await this.prisma.faces.create({ data: { ...faceData, characterId: character.id } });
     return this.prisma.characters.findFirst({ where: { id: character.id }, include: { face: true } });


### PR DESCRIPTION
These aren't necessarily the _right_ solution for this, but it does patch the hard errors existing from a fresh setup preventing initial startup and connection. Feel free to close of course if you'd rather implement an alternative solution, just figured I'd note it at least here :)

- `characters` socket manager was throwing a TS error from line 31 in `createCharacter`
- `accounts` socket manager with `getOrCreate` wasn't handling identifiers properly
  - Error thrown with `license` and `license2` because they don't exist in the schema
  - I had seeded an account creation and when `prisma.accounts.findFirst` was passed both `steam` and `discord` identifiers, it wasn't returning the matching account for `steam`, so it moved on to `createAccount` which then errored from `prisma.accounts.create` because it wasn't a unique entry, as the seeded account already had the matching `identifier_steam`. Removing `discord` so only `steam` was passed to `prisma.accounts.findFirst` resolved the issue