### PR TITLE
Switch weather grid seeding from BFS to a greedy wave function collapse.

### DIFF
--- a/resources/weather/README.md
+++ b/resources/weather/README.md
@@ -6,6 +6,7 @@ A grid-based spatial weather system for RedM that provides smooth, directional w
 
 - [Architecture](#architecture)
 - [Grid Structure](#grid-structure)
+- [Grid Generation](#grid-generation)
 - [Weather Compatibility Graph](#weather-compatibility-graph)
 - [Smooth Transition Engine](#smooth-transition-engine)
 - [Spatial Transition System](#spatial-transition-system)
@@ -101,6 +102,64 @@ Each cell is divided into two zones:
 
 - **Inner 50%**: Settled zone — no transitions, stable weather
 - **Outer 50%**: Transition zone — weather blends based on distance from center
+
+## Grid Generation
+
+Grid generation runs in two phases when `generateBiomeAwareWeather()` is called.
+
+### Phase 1 — Seeding
+
+For each biome, roughly 30% of its cells are selected as seed points (minimum 1). Each seed cell is assigned a randomly chosen weather type from `BIOME_WEATHER_RULES[biome]`, subject to compatibility with any already-placed seeds nearby. Cells that cannot satisfy constraints are skipped. Successfully seeded cells are added to `assignedCells`.
+
+### Phase 2 — Fill: Greedy Wave Function Collapse
+
+The remaining unassigned cells are filled using a **greedy Wave Function Collapse (WFC)** algorithm. The key property is that exactly **one cell is committed per iteration**, always chosen as the most-constrained frontier cell — the unassigned cell adjacent to at least one assigned cell that has the fewest remaining valid weather options.
+
+```
+while frontier cells exist:
+  for each unassigned cell adjacent to an assigned cell:
+    compute valid options = biome types ∩ compatible with all assigned neighbours
+  pick cell with fewest valid options  ← most constrained first
+  assign it, add to assignedCells
+  repeat
+```
+
+#### Why BFS was replaced
+
+The original implementation used a **Breadth-First Search (BFS) wave expansion**. Seeds were placed into a queue and the grid was filled by processing neighbours in wave order. This introduced a systematic race condition:
+
+```
+BFS wave 2 — two adjacent cells processed in the same pass:
+
+   Seed A (assigned)
+   │
+   ├── Cell X  ← queued, assigned RAIN  (sees only A)
+   └── Cell Y  ← queued, assigned RAIN  (also sees only A)
+
+   Result: X and Y are adjacent and both RAIN — compatibility violation
+```
+
+Because BFS commits multiple cells per wave, cells in the same wave are assigned without seeing each other as constraints. The larger the grid and the more seeds, the more frequently two frontier cells in the same wave ended up adjacent with conflicting or identical weather.
+
+The greedy WFC eliminates this entirely. By committing one cell at a time and immediately adding it to `assignedCells`, every subsequent candidate sees the fully up-to-date constraint state. No two cells are ever assigned in the same step, so the race condition cannot occur.
+
+#### Most-constrained-first heuristic
+
+Choosing the cell with the **fewest remaining valid options** is a standard WFC technique to reduce contradictions. A cell with only one valid option must be assigned that option immediately — deferring it risks adjacent cells consuming that option, leaving it with zero valid choices. Assigning tight cells first keeps the constraint space maximally open for cells that have more flexibility.
+
+#### Fallback handling
+
+If a frontier cell reaches zero valid options (constraint deadlock), the algorithm does not backtrack. Instead it applies a progressive relaxation:
+
+1. **Best partial match** — scores each biome-allowed type by how many of its assigned neighbours it is compatible with, and picks the highest-scoring type(s). This minimises the number of constraint violations rather than picking arbitrarily.
+2. **Deadlock fallback** — if all biome types are blocked by same-type constraints (e.g., a desert biome with only 3–4 types whose neighbours already hold all of them), the scoring is repeated allowing same-type candidates, favouring the one most compatible with non-same-type neighbours. This produces at most one same-type adjacency rather than silently leaving the cell at the default placeholder.
+3. **Safety net** — immediately before selection, any candidate that would duplicate an assigned neighbour's weather type is removed from the candidate list (if doing so still leaves at least one option). This catches same-type slippage from the fallback path.
+
+Deadlocks only occur in very small biomes at the edge of the map (e.g., RIO_BRAVO with 3 cell types) where the 8-directional neighbourhood can exhaust the entire biome palette. These cases are kept rare by ensuring each biome has enough weather types to satisfy typical neighbourhood configurations.
+
+### `assignedCells` tracking
+
+Both `isCompatibleWithNeighbors` and `getCompatibleWeatherTypes` skip neighbours that are not in `assignedCells`. This means the default `CLOUDS` placeholder that cells hold before assignment is never treated as a constraint. Without this, every unassigned cell would appear to have `CLOUDS` weather and heavily skew the compatibility filtering before any real assignment had taken place.
 
 ## Weather Compatibility Graph
 

--- a/resources/weather/src/client/client.ts
+++ b/resources/weather/src/client/client.ts
@@ -1,6 +1,4 @@
 import { PVGame } from '@lib/client';
-import { Log } from '@lib/client/comms/ui';
-import { Vector3 } from '@lib/math';
 
 import {
   WEATHER_COMPATIBILITY,

--- a/resources/weather/src/shared/grid.ts
+++ b/resources/weather/src/shared/grid.ts
@@ -811,7 +811,6 @@ class BiomeWeatherGrid {
       direction = 'unknown';
       console.log(`Heading ${heading} is unknown, defaulting to N (${dirX}, ${dirY})`);
       Log(`Heading ${heading} is unknown, defaulting to N (${dirX}, ${dirY})`);
-      Log(`Heading ${heading} is unknown, defaulting to N (${dirX}, ${dirY})`);
     }
     
     const neighborGridX = gridPos.x + dirX;

--- a/resources/weather/src/shared/types.ts
+++ b/resources/weather/src/shared/types.ts
@@ -15,6 +15,7 @@ export interface GridCell {
   variant: string | null;
   biome: BiomeType;
   rainRate: number; // 0.0 - 1.0, only applies to RAIN, SHOWER, DRIZZLE, THUNDERSTORM
+  assigned?: boolean; // internal generation flag — not sent to clients
 }
 
 /**

--- a/socket/src/managers/weather.ts
+++ b/socket/src/managers/weather.ts
@@ -694,6 +694,7 @@ export class BiomeWeatherGrid {
   private width: number;
   private height: number;
   private biomeManager: BiomeManager;
+  private assignedCells: Set<string> = new Set();
 
   private readonly MAP_MIN_X = -5632.0;
   private readonly MAP_MAX_X = 6144.0;
@@ -793,13 +794,28 @@ export class BiomeWeatherGrid {
 
     for (const neighbor of neighbors) {
       const neighborCell = this.grid[neighbor.y][neighbor.x];
+      if (!this.assignedCells.has(`${neighbor.x},${neighbor.y}`)) {
+        continue;
+      }
+
       const neighborWeather = neighborCell.weather;
+      if (weatherType === neighborWeather) {
+        return false;
+      }
+
+      if (compatibleWeathers.length === 0) {
+        return false;
+      }
+
+      const neighborCompatible = WEATHER_COMPATIBILITY[neighborWeather];
+      if (neighborCompatible.length === 0) {
+        continue;
+      }
 
       if (!compatibleWeathers.includes(neighborWeather)) {
         return false;
       }
 
-      const neighborCompatible = WEATHER_COMPATIBILITY[neighborWeather];
       if (!neighborCompatible.includes(weatherType)) {
         return false;
       }
@@ -822,11 +838,28 @@ export class BiomeWeatherGrid {
     }
 
     for (const neighbor of neighbors) {
-      const neighborWeather = this.grid[neighbor.y][neighbor.x].weather;
+      const neighborCell = this.grid[neighbor.y][neighbor.x];
+      if (!this.assignedCells.has(`${neighbor.x},${neighbor.y}`)) {
+        continue;
+      }
+
+      const neighborWeather = neighborCell.weather;
       const neighborCompatible = WEATHER_COMPATIBILITY[neighborWeather];
 
       compatible = new Set(
         Array.from(compatible).filter((w) => {
+          // Adjacent cells cannot share the same weather type
+          if (w === neighborWeather) {
+            return false;
+          }
+          // Exclude isolated types (empty compatibility) — they can't validly neighbour anything assigned
+          if (WEATHER_COMPATIBILITY[w].length === 0) {
+            return false;
+          }
+          // If the neighbor is an isolated type, only the same-type check matters
+          if (neighborCompatible.length === 0) {
+            return true;
+          }
           const isInNeighborCompatible = neighborCompatible.includes(w);
           const neighborIsInWeatherCompatible = WEATHER_COMPATIBILITY[w].includes(neighborWeather);
           return isInNeighborCompatible && neighborIsInWeatherCompatible;
@@ -861,6 +894,7 @@ export class BiomeWeatherGrid {
     cell.weather = weatherType;
     cell.variant = this.getRandomVariant(weatherType, cell.biome);
     cell.rainRate = getRainRate(weatherType);
+    this.assignedCells.add(`${x},${y}`);
     return true;
   }
 
@@ -868,7 +902,8 @@ export class BiomeWeatherGrid {
    * Initialize the grid with biome-appropriate random weather
    */
   public generateBiomeAwareWeather(seed?: number): void {
-    const random = seed !== undefined ? this.seededRandom(seed) : Math.random;
+    let random = seed !== undefined ? this.seededRandom(seed) : Math.random;
+    this.assignedCells.clear();
 
     const biomeGroups = new Map<BiomeType, GridCell[]>();
 
@@ -903,6 +938,7 @@ export class BiomeWeatherGrid {
           if (this.isCompatibleWithNeighbors(seedCell.x, seedCell.y, weatherType)) {
             seedCell.variant = this.getRandomVariant(weatherType, biome, random);
             seedCell.rainRate = getRainRate(weatherType, random);
+            this.assignedCells.add(`${seedCell.x},${seedCell.y}`);
             placedSeeds++;
             break;
           } else {
@@ -912,44 +948,116 @@ export class BiomeWeatherGrid {
       }
     });
 
-    const queue: GridCell[] = [];
-    const visited = new Set<string>();
+    // Greedy WFC fill: assign one cell per iteration — always the frontier cell with
+    // the fewest valid options (most constrained first). Because each assignment is
+    // committed to assignedCells before the next candidate is selected, every
+    // subsequent assignment sees the complete current constraint state. This eliminates
+    // the race condition with previous BFS implementation where two adjacent cells could
+    // be assigned in the same "wave" without seeing each other as constraints.
+    while (true) {
+      let bestX = -1, bestY = -1;
+      let bestCompatible: WeatherType[] = [];
+      let fewestOptions = Infinity;
+      let hasFrontierCell = false;
 
-    this.grid.forEach((row) => {
-      row.forEach((cell) => {
-        if (
-          cell.weather !== WeatherType.CLOUDS ||
-          this.biomeManager.isWeatherAllowedInBiome(WeatherType.CLOUDS, cell.biome)
-        ) {
-          queue.push(cell);
-          visited.add(`${cell.x},${cell.y}`);
-        }
-      });
-    });
+      for (let y = 0; y < this.height; y++) {
+        for (let x = 0; x < this.width; x++) {
+          if (this.assignedCells.has(`${x},${y}`)) continue;
+          if (!this.getNeighbors(x, y).some(n => this.assignedCells.has(`${n.x},${n.y}`))) continue;
 
-    while (queue.length > 0) {
-      const current = queue.shift()!;
-      const neighbors = this.getNeighbors(current.x, current.y);
+          hasFrontierCell = true;
+          const compatible = this.getCompatibleWeatherTypes(x, y);
 
-      for (const neighbor of neighbors) {
-        const key = `${neighbor.x},${neighbor.y}`;
-
-        if (!visited.has(key)) {
-          visited.add(key);
-          const neighborCell = this.grid[neighbor.y][neighbor.x];
-
-          const compatible = this.getCompatibleWeatherTypes(neighbor.x, neighbor.y);
-
-          if (compatible.length > 0) {
-            const selectedWeather = this.selectDiverseWeather(neighbor.x, neighbor.y, compatible, random);
-            neighborCell.weather = selectedWeather;
-            neighborCell.variant = this.getRandomVariant(selectedWeather, neighborCell.biome, random);
-            neighborCell.rainRate = getRainRate(selectedWeather, random);
+          // Prefer cells with the fewest positive options (most constrained).
+          // Cells with 0 options are tracked separately and only used as fallback.
+          if (compatible.length > 0 && compatible.length < fewestOptions) {
+            fewestOptions = compatible.length;
+            bestX = x;
+            bestY = y;
+            bestCompatible = compatible;
           }
-
-          queue.push(neighborCell);
         }
       }
+
+      if (!hasFrontierCell) break; // All cells assigned or unreachable
+
+      // If every frontier cell has 0 strict options, pick the first one for fallback
+      if (bestX === -1) {
+        outer: for (let y = 0; y < this.height; y++) {
+          for (let x = 0; x < this.width; x++) {
+            if (this.assignedCells.has(`${x},${y}`)) continue;
+            if (!this.getNeighbors(x, y).some(n => this.assignedCells.has(`${n.x},${n.y}`))) continue;
+            bestX = x; bestY = y;
+            break outer;
+          }
+        }
+      }
+
+      const key = `${bestX},${bestY}`;
+      const cell = this.grid[bestY][bestX];
+      let compatible = bestCompatible;
+
+      // Fallback: strict WFC found no valid option — relax constraints progressively.
+      // Rather than ignoring compatibility entirely, pick the type most compatible with
+      // the most assigned neighbours (best partial match), which minimises violations.
+      if (compatible.length === 0) {
+        const assignedNeighbors = this.getNeighbors(bestX, bestY)
+          .filter(n => this.assignedCells.has(`${n.x},${n.y}`));
+        const assignedNeighborWeathers = assignedNeighbors.map(n => this.grid[n.y][n.x].weather);
+        const assignedSet = new Set(assignedNeighborWeathers);
+
+        const biomeWeathers = BIOME_WEATHER_RULES[cell.biome].filter(w => !assignedSet.has(w));
+
+        // Score each candidate by how many assigned neighbours it is compatible with
+        const scored = biomeWeathers.map(w => {
+          const score = assignedNeighborWeathers.filter(nw =>
+            WEATHER_COMPATIBILITY[w].includes(nw) && WEATHER_COMPATIBILITY[nw].includes(w)
+          ).length;
+          return { w, score };
+        });
+
+        if (scored.length > 0) {
+          const maxScore = Math.max(...scored.map(s => s.score));
+          compatible = scored.filter(s => s.score === maxScore).map(s => s.w);
+        }
+
+        // Deadlock: all biome types are blocked by same-type constraints.
+        // Re-score including same-type types, picking whichever is most compatible
+        // with non-same-type neighbours. This produces at most one same-type
+        // violation rather than silently leaving the cell at the default CLOUDS.
+        if (compatible.length === 0) {
+          const allBiomeTypes = BIOME_WEATHER_RULES[cell.biome];
+          const deadlockScored = allBiomeTypes.map(w => {
+            const score = assignedNeighborWeathers.filter(nw =>
+              nw !== w &&
+              WEATHER_COMPATIBILITY[w].includes(nw) &&
+              WEATHER_COMPATIBILITY[nw].includes(w)
+            ).length;
+            return { w, score };
+          });
+          const maxDeadlockScore = Math.max(...deadlockScored.map(s => s.score));
+          compatible = deadlockScored.filter(s => s.score === maxDeadlockScore).map(s => s.w);
+          if (compatible.length === 0) compatible = allBiomeTypes;
+        }
+      }
+
+      if (compatible.length > 0) {
+        // Safety net: remove any types that would duplicate an assigned neighbour's weather
+        // (only if doing so still leaves valid candidates — avoids leaving cell unassigned).
+        const assignedNeighbourSet = new Set<WeatherType>(
+          this.getNeighbors(bestX, bestY)
+            .filter(n => this.assignedCells.has(`${n.x},${n.y}`))
+            .map(n => this.grid[n.y][n.x].weather)
+        );
+        const safeCompatible = compatible.filter(w => !assignedNeighbourSet.has(w));
+        const finalCompatible = safeCompatible.length > 0 ? safeCompatible : compatible;
+
+        const selectedWeather = this.selectDiverseWeather(bestX, bestY, finalCompatible, random);
+        cell.weather = selectedWeather;
+        cell.variant = this.getRandomVariant(selectedWeather, cell.biome, random);
+        cell.rainRate = getRainRate(selectedWeather, random);
+      }
+      this.assignedCells.add(key); // Always mark assigned to advance the frontier
     }
   }
 


### PR DESCRIPTION
The current BFS implementation has a race condition due to the non-exclusive queue order & processing within each "wave" (next node). This allows for race conditions to exist that allows for neighboring cells to co-exist that violate the compatibility matrix since they don't know about the other cells constraints, leading to cases of neighboring cells horizontally, vertically, diagonally that are all of the same type. 

By moving to a wave function collapse implementation the most constrained cell is always processed first and committed before the next cell is processed. This doesn't entirely prevent neighboring cells from having the same weather type (see deadlock scenarios) but does reduce the likelihood of it occurring. See updated `README.md` for more info.

This results in a more varied grid generation in comparison to BFS.

**Before (BFS)**: 
```
socket: === Weather Grid (with Biomes) ===
socket: HIGH | CLOU | OVER | DRIZ | OVER | DRIZ | CLOU | DRIZ
socket: -----------------------------------------------------
socket: SUNN | DRIZ | RAIN | CLOU | RAIN | FOG  | OVER | FOG 
socket: -----------------------------------------------------
socket: HIGH | CLOU | OVER | DRIZ | THUN | DRIZ | CLOU | DRIZ
socket: -----------------------------------------------------
socket: SUNN | CLOU | OVER | MIST | RAIN | MIST | FOG  | OVER
socket: -----------------------------------------------------
socket: OVER | OVER | CLOU | DRIZ | OVER | DRIZ | OVER | DRIZ
socket: -----------------------------------------------------
socket: CLOU | RAIN | OVER | OVER | CLOU | FOG  | OVER | CLOU
socket: -----------------------------------------------------
socket: OVER | DRIZ | CLOU | FOG  | SNOW | SUNN | OVER | FOG 
socket: -----------------------------------------------------
socket: RAIN | OVER | MIST | OVER | CLOU | OVER | CLOU | OVER
```

**After (Greedy WFC)**:
```
socket: === Weather Grid (with Biomes) ===
socket: HIGH | CLOU | DRIZ | THUN | RAIN | SHOW | RAIN | THUN
socket: -----------------------------------------------------
socket: SUNN | OVER | RAIN | OVER | THUN | THUN | HURR | SHOW
socket: -----------------------------------------------------
socket: CLOU | HIGH | THUN | DRIZ | CLOU | DRIZ | OVER | THUN
socket: -----------------------------------------------------
socket: OVER | SUNN | CLOU | THUN | THUN | RAIN | SHOW | RAIN
socket: -----------------------------------------------------
socket: CLOU | OVER | FOG  | DRIZ | OVER | DRIZ | OVER | DRIZ
socket: -----------------------------------------------------
socket: OVER | DRIZ | OVER | CLOU | FOG  | CLOU | OVER | RAIN
socket: -----------------------------------------------------
socket: SUNN | CLOU | FOG  | MIST | SNOW | OVER | DRIZ | OVER
socket: -----------------------------------------------------
socket: HIGH | DRIZ | OVER | CLOU | FOG  | CLOU | FOG  | MIST
```