### PR TITLE
add generic ped manager class for NPCs.

### DIFF
--- a/lib/client/PED_MANAGER.md
+++ b/lib/client/PED_MANAGER.md
@@ -1,0 +1,189 @@
+# PedManager
+
+Client-side lifecycle manager for resource-owned NPC peds. Each resource instantiates its own `PedManager` — there is no global singleton.
+
+```ts
+import { PedManager } from '@lib/client';
+
+const manager = new PedManager();
+```
+
+---
+
+## Spawning & despawning
+
+```ts
+const handle = await manager.spawn('my-ped', config);
+manager.despawn('my-ped');
+manager.despawnAll();
+
+// Get the entity handle for a managed ped
+const handle = manager.getPed('my-ped');
+```
+
+`spawn` is idempotent — calling it with the same id twice returns the existing handle. `despawn` cleans up the entity, stops all timers and ticks, and removes the ped from tracking.
+
+---
+
+## PedConfig
+
+```ts
+interface PedConfig {
+  model: string | number;
+  position: { x: number; y: number; z: number; w: number }; // w = heading
+  networked?: boolean;       // default false
+  freeze?: boolean;          // FreezeEntityPosition
+  invincible?: boolean;      // SetEntityInvincible
+  blockEvents?: boolean;     // SetBlockingOfNonTemporaryEvents
+  missionEntity?: boolean;   // SetEntityAsMissionEntity (cleaned up on despawn)
+  scenario?: string;         // one-shot scenario on spawn (overridden if routine is set)
+  speech?: PedSpeechConfig;
+  routine?: RoutineStep[];
+  reactions?: PedReactionConfig[];
+}
+```
+
+---
+
+## Ambient speech loop
+
+Fires a random line from the pool on a random interval. Runs independently of the routine.
+
+```ts
+speech: {
+  ref: '0822_S_M_M_BANKCLERK_01_WHITE_01',
+  lines: ['HOWS_IT_GOING', 'WELCOME'],
+  params: 'speech_params_force',
+  intervalMs: [15_000, 45_000], // [min, max] ms — picked randomly each time
+}
+```
+
+> **Note:** Ambient speech is routed through a Lua event handler (`game:playAmbientSpeech` in `resources/game/lua/client.lua`). This is intentional and must not be moved to TypeScript — `PlayPedAmbientSpeechNative` requires 64-bit memory pointers from `VarString` which cannot be represented safely in JS IEEE 754 floats. The TypeScript export `playAmbientSpeechFromEntity` in `game-manager.ts` was tested and confirmed to crash for this reason.
+
+---
+
+## Scripted routines
+
+A routine is a looping sequence of steps executed in order. Supports four step types:
+
+```ts
+routine: [
+  // Play a named scenario for a duration then move to the next step
+  { type: 'scenario', name: 'WORLD_HUMAN_VAL_BANKTELLER', duration: 10_000 },
+
+  // Play an animation dict/clip for a duration
+  { type: 'anim', dict: 'amb@world_human_stand_impatient@male@base', anim: 'base', duration: 4_000 },
+
+  // Fire a one-shot speech line mid-routine
+  { type: 'speech', ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'GENERIC_THANKS', params: 'speech_params_force' },
+
+  // Pause before the next step
+  { type: 'wait', ms: 2_000 },
+]
+```
+
+All steps log to the console when executed (`[PedManager] routine "<id>" ...`).
+
+### Pausing and resuming
+
+```ts
+manager.pauseRoutine('my-ped');
+manager.resumeRoutine('my-ped');
+```
+
+When paused the routine tick keeps running but skips all steps, polling every 500ms until resumed.
+
+---
+
+## Event-based reactions
+
+Reactions listen for game events and fire a random speech line from a pool when triggered. Each reaction has an independent cooldown.
+
+```ts
+reactions: [
+  {
+    // Event name — must be a key of EventData (see lib/client/events.ts)
+    event: 'EVENT_ENTITY_DAMAGED',
+
+    // Optional: only react if this field in the event data matches this ped's handle.
+    // Omit to react to the event regardless of which entity was involved.
+    entityField: 'attacked',
+
+    // Random pick from this pool each time
+    lines: [
+      { ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'GENERIC_FRIGHTENED_HIGH', params: 'speech_params_force' },
+      { ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'GENERIC_FRIGHTENED_MED',  params: 'speech_params_force' },
+    ],
+
+    // Minimum ms between triggers for this reaction. Default: 5000
+    cooldownMs: 8_000,
+
+    // Optional callback — runs alongside the speech line
+    onReact: (pedHandle, data) => {
+      console.log(`ped ${pedHandle} was hit by ${data.attacker}`);
+    },
+  },
+]
+```
+
+### Entity matching
+
+| `entityField` set | Behaviour |
+|---|---|
+| Yes | Only fires if `data[entityField] === pedHandle` |
+| No | Fires on any occurrence of the event (ped handle not checked) |
+
+### Available events
+
+Events must be mapped in `lib/client/events.ts` (`eventMappings`) to be usable as a `PedReactionConfig.event`. Currently mapped events relevant to peds:
+
+| Event | Key fields |
+|---|---|
+| `EVENT_ENTITY_DAMAGED` | `attacked`, `attacker`, `weaponHash`, `damage` |
+| `EVENT_ENTITY_DESTROYED` | `attacked`, `attacker`, `weaponHash` |
+| `EVENT_ENTITY_EXPLOSION` | `pedOrigin`, `weaponHash`, `x`, `y`, `z` |
+| `EVENT_SHOT_FIRED_BULLET_IMPACT` | `shooter` |
+| `EVENT_CRIME_CONFIRMED` | `ped` |
+| `EVENT_LOOT_COMPLETE` | `playerPed`, `entity` |
+
+To add a new event, add its field mapping to `eventMappings` in `lib/client/events.ts`. The size (number of fields) can be found in `resources/[core]/events_manager/client/handler.lua`.
+
+---
+
+## Full example
+
+```ts
+const manager = new PedManager();
+
+const handle = await manager.spawn('valentine-teller', {
+  model: 'mp_m_m_bankclerk01_01',
+  position: { x: -252.8, y: 764.2, z: 118.9, w: 90 },
+  freeze: true,
+  invincible: true,
+  blockEvents: true,
+  missionEntity: true,
+  speech: {
+    ref: '0822_S_M_M_BANKCLERK_01_WHITE_01',
+    lines: ['HOWS_IT_GOING', 'WELCOME'],
+    params: 'speech_params_force',
+    intervalMs: [15_000, 45_000],
+  },
+  routine: [
+    { type: 'scenario', name: 'WORLD_HUMAN_VAL_BANKTELLER', duration: 10_000 },
+    { type: 'wait', ms: 2_000 },
+  ],
+  reactions: [
+    {
+      event: 'EVENT_ENTITY_DAMAGED',
+      entityField: 'attacked',
+      cooldownMs: 8_000,
+      lines: [
+        { ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'GENERIC_FRIGHTENED_HIGH', params: 'speech_params_force' },
+      ],
+      onReact: (ped, data) => {
+        // e.g. trigger flee, notify server, etc.
+      },
+    },
+  ],
+});
+```

--- a/lib/client/PED_MANAGER.md
+++ b/lib/client/PED_MANAGER.md
@@ -5,7 +5,7 @@ Client-side lifecycle manager for resource-owned NPC peds. Each resource instant
 ```ts
 import { PedManager } from '@lib/client';
 
-const manager = new PedManager();
+const manager = PedManager().getInstance();
 ```
 
 ---
@@ -52,7 +52,7 @@ Fires a random line from the pool on a random interval. Runs independently of th
 ```ts
 speech: {
   ref: '0822_S_M_M_BANKCLERK_01_WHITE_01',
-  lines: ['HOWS_IT_GOING', 'WELCOME'],
+  names: ['HOWS_IT_GOING', 'WELCOME'],
   params: 'speech_params_force',
   intervalMs: [15_000, 45_000], // [min, max] ms — picked randomly each time
 }
@@ -164,7 +164,7 @@ const handle = await manager.spawn('valentine-teller', {
   missionEntity: true,
   speech: {
     ref: '0822_S_M_M_BANKCLERK_01_WHITE_01',
-    lines: ['HOWS_IT_GOING', 'WELCOME'],
+    names: ['HOWS_IT_GOING', 'WELCOME'],
     params: 'speech_params_force',
     intervalMs: [15_000, 45_000],
   },

--- a/lib/client/events.ts
+++ b/lib/client/events.ts
@@ -188,6 +188,16 @@ const eventMappings = {
     _0: 'i',
     _1: 'i',
   },
+  // size = 1: the ped who fired the shot
+  EVENT_SHOT_FIRED_BULLET_IMPACT: {
+    shooter: 'i',
+  },
+  // size = 3: crime entity + two unknown fields
+  EVENT_CRIME_CONFIRMED: {
+    ped: 'i',
+    _1: 'i',
+    _2: 'i',
+  },
   weapon: {
     mainHand: 'i',
     offHand: 'i',

--- a/lib/client/index.ts
+++ b/lib/client/index.ts
@@ -4,6 +4,8 @@ export { DrawLine, DrawTxt, TxtAtWorldCoord } from './functions';
 export * from './resources';
 export * from './game';
 export * from './events';
+export { PedManager } from './ped-manager';
+export type { PedConfig, PedSpeechConfig, RoutineStep, PedReactionConfig, ReactionSpeech } from './ped-manager';
 
 // @ts-ignore
 export const exports: ClientExports = global.exports;

--- a/lib/client/ped-manager.ts
+++ b/lib/client/ped-manager.ts
@@ -9,7 +9,7 @@ const playAmbientSpeech = (entity: number, ref: string, name: string, params: st
 
 export interface PedSpeechConfig {
   ref: string;
-  lines: string[];
+  names: string[];
   params: string;
   /** [minMs, maxMs] random interval between speech lines */
   intervalMs: [number, number];
@@ -75,9 +75,17 @@ interface ManagedPed {
 const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
 
 export class PedManager {
+  protected static instance: PedManager;
   private _peds: Map<string, ManagedPed> = new Map();
   /** Events that have already been registered with PVGameEvents (per-instance). */
   private _registeredReactionEvents: Set<keyof EventData> = new Set();
+
+  static getInstance(): PedManager {
+    if (!PedManager.instance) {
+      PedManager.instance = new PedManager();
+    }
+    return PedManager.instance;
+  }
 
   async spawn(id: string, config: PedConfig): Promise<number> {
     const existing = this._peds.get(id);
@@ -150,6 +158,18 @@ export class PedManager {
     if (managed) managed.routineRunning = true;
   }
 
+  playSpeech(id: string, psc: PedSpeechConfig): void {
+    const managed = this._peds.get(id);
+    console.log(`[PedManager] ped found: ${!!managed} with handle ${managed?.handle} - playSpeech "${id}" ref=${psc.ref} names=${psc.names.join(',')} params=${psc.params}`);
+
+    if (managed && DoesEntityExist(managed.handle)) {
+      if (managed.routineRunning) this.pauseRoutine(id);
+      const line = psc.names[Math.floor(Math.random() * psc.names.length)];
+      playAmbientSpeech(managed.handle, psc.ref, line, psc.params);
+      if (!managed.routineRunning) this.resumeRoutine(id);
+    }
+  }
+
   private _startSpeechLoop(managed: ManagedPed): void {
     const { speech } = managed.config;
     if (!speech) return;
@@ -158,7 +178,7 @@ export class PedManager {
       const delay = randomBetween(speech.intervalMs[0], speech.intervalMs[1]);
       managed.speechTimer = setTimeout(() => {
         if (DoesEntityExist(managed.handle)) {
-          const line = speech.lines[Math.floor(Math.random() * speech.lines.length)];
+          const line = speech.lines[Math.floor(Math.random() * speech.names.length)];
           playAmbientSpeech(managed.handle, speech.ref, line, speech.params);
         }
         schedule();

--- a/lib/client/ped-manager.ts
+++ b/lib/client/ped-manager.ts
@@ -1,0 +1,277 @@
+import { Delay } from '@lib/functions';
+
+import { PVGameEvents, type EventData } from './events';
+import { PVGame } from './resources';
+
+const playAmbientSpeech = (entity: number, ref: string, name: string, params: string, line = 0) => {
+  emit('game:playAmbientSpeech', entity, ref, name, params, line);
+};
+
+export interface PedSpeechConfig {
+  ref: string;
+  lines: string[];
+  params: string;
+  /** [minMs, maxMs] random interval between speech lines */
+  intervalMs: [number, number];
+}
+
+export type RoutineStep =
+  | { type: 'scenario'; name: string; duration?: number }
+  | { type: 'anim'; dict: string; anim: string; flags?: number; duration?: number }
+  | { type: 'wait'; ms: number }
+  | { type: 'speech'; ref: string; name: string; params: string };
+
+/** A single speech variant for a reaction — picked randomly from the pool. */
+export interface ReactionSpeech {
+  ref: string;
+  name: string;
+  params: string;
+}
+
+/**
+ * Reaction config for a game event.
+ *
+ * `entityField` — the field in the event data that contains the entity handle
+ * to match against this ped. Defaults to checking all numeric values in the
+ * event data. Most events use 'attacked', 'ped', or similar.
+ *
+ * `cooldownMs` — minimum ms between reaction triggers for this event.
+ * Defaults to 5000ms to avoid speech spam.
+ */
+export interface PedReactionConfig {
+  event: keyof EventData;
+  /** Field name in the event data whose value is compared against the ped handle. Omit to skip entity matching and always fire. */
+  entityField?: string;
+  lines: ReactionSpeech[];
+  cooldownMs?: number;
+  /** Optional callback fired alongside the speech reaction. Receives the ped handle and the raw event data. */
+  onReact?: (pedHandle: number, data: Record<string, number>) => void;
+}
+
+export interface PedConfig {
+  model: string | number;
+  position: { x: number; y: number; z: number; w: number };
+  networked?: boolean;
+  freeze?: boolean;
+  invincible?: boolean;
+  blockEvents?: boolean;
+  missionEntity?: boolean;
+  scenario?: string;
+  speech?: PedSpeechConfig;
+  routine?: RoutineStep[];
+  reactions?: PedReactionConfig[];
+}
+
+interface ManagedPed {
+  id: string;
+  handle: number;
+  config: PedConfig;
+  speechTimer?: CitizenTimer;
+  routineTick?: number;
+  routineRunning: boolean;
+  reactionCooldowns: Map<string, number>;
+}
+
+const randomBetween = (min: number, max: number) => Math.random() * (max - min) + min;
+
+export class PedManager {
+  private _peds: Map<string, ManagedPed> = new Map();
+  /** Events that have already been registered with PVGameEvents (per-instance). */
+  private _registeredReactionEvents: Set<keyof EventData> = new Set();
+
+  async spawn(id: string, config: PedConfig): Promise<number> {
+    const existing = this._peds.get(id);
+    if (existing) return existing.handle;
+
+    const { x, y, z, w } = config.position;
+    await PVGame.loadModel(config.model);
+    const handle = await PVGame.createPed(config.model, x, y, z, w, true, config.networked ?? false);
+
+    if (!handle || !DoesEntityExist(handle)) {
+      console.warn(`[PedManager] Failed to spawn ped "${id}"`);
+      return 0;
+    }
+
+    if (config.missionEntity) SetEntityAsMissionEntity(handle, true, true);
+    if (config.invincible) SetEntityInvincible(handle, true);
+    if (config.freeze) FreezeEntityPosition(handle, true);
+    if (config.blockEvents) SetBlockingOfNonTemporaryEvents(handle, true);
+
+    SetPedFleeAttributes(handle, 0, false);
+    SetPedCombatAttributes(handle, 17, true);
+
+    if (config.scenario) {
+      TaskStartScenarioInPlace_2(handle, null, config.scenario, 0, true, 0, false);
+    }
+
+    const managed: ManagedPed = { id, handle, config, routineRunning: true, reactionCooldowns: new Map() };
+    this._peds.set(id, managed);
+
+    if (config.speech) this._startSpeechLoop(managed);
+    if (config.routine?.length) this._startRoutine(managed);
+    if (config.reactions?.length) this._registerReactions(managed);
+
+    return handle;
+  }
+
+  despawn(id: string): void {
+    const managed = this._peds.get(id);
+    if (!managed) return;
+
+    this._stopSpeechLoop(managed);
+    this._stopRoutine(managed);
+
+    const { handle, config } = managed;
+    if (DoesEntityExist(handle)) {
+      if (config.missionEntity) SetEntityAsMissionEntity(handle, false, true);
+      DeletePed(handle);
+    }
+
+    this._peds.delete(id);
+  }
+
+  despawnAll(): void {
+    for (const id of this._peds.keys()) {
+      this.despawn(id);
+    }
+  }
+
+  getPed(id: string): number | undefined {
+    return this._peds.get(id)?.handle;
+  }
+
+  pauseRoutine(id: string): void {
+    const managed = this._peds.get(id);
+    if (managed) managed.routineRunning = false;
+  }
+
+  resumeRoutine(id: string): void {
+    const managed = this._peds.get(id);
+    if (managed) managed.routineRunning = true;
+  }
+
+  private _startSpeechLoop(managed: ManagedPed): void {
+    const { speech } = managed.config;
+    if (!speech) return;
+
+    const schedule = () => {
+      const delay = randomBetween(speech.intervalMs[0], speech.intervalMs[1]);
+      managed.speechTimer = setTimeout(() => {
+        if (DoesEntityExist(managed.handle)) {
+          const line = speech.lines[Math.floor(Math.random() * speech.lines.length)];
+          playAmbientSpeech(managed.handle, speech.ref, line, speech.params);
+        }
+        schedule();
+      }, delay);
+    };
+
+    schedule();
+  }
+
+  private _stopSpeechLoop(managed: ManagedPed): void {
+    if (managed.speechTimer !== undefined) {
+      clearTimeout(managed.speechTimer);
+      managed.speechTimer = undefined;
+    }
+  }
+
+  private _startRoutine(managed: ManagedPed): void {
+    const steps = managed.config.routine;
+    if (!steps?.length) return;
+
+    managed.routineTick = setTick(async () => {
+      for (const step of steps) {
+        if (!managed.routineRunning || !DoesEntityExist(managed.handle)) {
+          await Delay(500);
+          continue;
+        }
+
+        switch (step.type) {
+          case 'scenario':
+            console.log(`[PedManager] routine "${managed.id}" scenario=${step.name} duration=${step.duration}`);
+            TaskStartScenarioInPlace_2(managed.handle, null, step.name, 0, true, 0, false);
+            if (step.duration) await Delay(step.duration);
+            break;
+
+          case 'anim':
+            console.log(`[PedManager] routine "${managed.id}" anim=${step.dict}@${step.anim} duration=${step.duration}`);
+            await PVGame.loadAnimDict(step.dict);
+            TaskPlayAnim(
+              managed.handle,
+              step.dict,
+              step.anim,
+              8.0,
+              -8.0,
+              step.duration ?? -1,
+              step.flags ?? 0,
+              0,
+              false,
+              false,
+              false,
+            );
+            if (step.duration) await Delay(step.duration);
+            break;
+
+          case 'wait':
+            console.log(`[PedManager] routine "${managed.id}" wait=${step.ms}ms`);
+            await Delay(step.ms);
+            break;
+
+          case 'speech':
+            console.log(`[PedManager] routine "${managed.id}" speech ref=${step.ref} name=${step.name}`);
+            playAmbientSpeech(managed.handle, step.ref, step.name, step.params);
+            break;
+        }
+      }
+    });
+  }
+
+  private _stopRoutine(managed: ManagedPed): void {
+    if (managed.routineTick !== undefined) {
+      clearTick(managed.routineTick);
+      managed.routineTick = undefined;
+    }
+  }
+
+  private _registerReactions(managed: ManagedPed): void {
+    const { reactions } = managed.config;
+    if (!reactions?.length) return;
+
+    for (const reaction of reactions) {
+      if (this._registeredReactionEvents.has(reaction.event)) continue;
+      this._registeredReactionEvents.add(reaction.event);
+
+      PVGameEvents.register(reaction.event, (data) => {
+        const now = Date.now();
+
+        for (const ped of this._peds.values()) {
+          if (!DoesEntityExist(ped.handle)) continue;
+
+          for (const r of ped.config.reactions ?? []) {
+            if (r.event !== reaction.event) continue;
+
+            // Check if the event involves this ped's entity handle.
+            const matched = r.entityField
+              ? (data as Record<string, number>)[r.entityField as string] === ped.handle
+              : Object.values(data as Record<string, number>).includes(ped.handle);
+
+            if (!matched) continue;
+
+            const cooldownKey = `${r.event}`;
+            const cooldown = r.cooldownMs ?? 5_000;
+            const lastFired = ped.reactionCooldowns.get(cooldownKey) ?? 0;
+
+            if (now - lastFired < cooldown) continue;
+
+            ped.reactionCooldowns.set(cooldownKey, now);
+
+            const line = r.lines[Math.floor(Math.random() * r.lines.length)];
+            console.log(`[PedManager] reaction "${ped.id}" event=${r.event} speech=${line.ref}/${line.name}`);
+            playAmbientSpeech(ped.handle, line.ref, line.name, line.params);
+            r.onReact?.(ped.handle, data as Record<string, number>);
+          }
+        }
+      });
+    }
+  }
+}

--- a/resources/game/lua/client.lua
+++ b/resources/game/lua/client.lua
@@ -1,4 +1,65 @@
- function getStateValue(entityId, key)
+--[[
+    AMBIENT SPEECH — WHY THIS MUST BE LUA, NOT TYPESCRIPT
+    -------------------------------------------------------
+    PlayPedAmbientSpeechNative (0x8E04FEDD28D42462) requires a struct where the
+    first two fields are 64-bit pointers returned by VarString (0xFA925AC00EB830B9).
+
+    In TypeScript/JS, all numbers are IEEE 754 float64, which can only represent
+    integers exactly up to 2^53. VarString returns a native memory pointer that
+    routinely exceeds this range (e.g. 140696472996639), meaning the value is
+    silently truncated when stored in a JS number. Writing this truncated value
+    into the struct via DataView.setBigInt64 produces a garbage pointer, causing
+    the native to crash with "exception at address RedM_GTAProcess.exe+25F799A".
+
+    Lua integers are true 64-bit integers (no float precision loss), so VarString
+    pointers survive the round-trip into the struct intact. There is no equivalent
+    safe path in the CFX v8 scripting API — resultAsLong() still returns a JS
+    number, losing the high bits. This function must remain in Lua.
+
+    NOTE: The existing TypeScript export GameManager.playAmbientSpeechFromEntity
+    (game-manager.ts) was tested and produces the same crash — BigInt(soundName)
+    wraps an already-truncated JS number, so the high bits are already gone before
+    BigInt sees the value. Do not attempt to move this back to TypeScript.
+--]]
+
+-- DataView implementation by gottfriedleibniz
+-- https://gist.github.com/gottfriedleibniz/8ff6e4f38f97dd43354a60f8494eedff
+local _strblob = string.blob or function(length) return string.rep("\0", math.max(40 + 1, length)) end
+local DataView = { EndBig = ">", EndLittle = "<", Types = { Int8={code="i1",size=1}, Uint8={code="I1",size=1}, Int16={code="i2",size=2}, Uint16={code="I2",size=2}, Int32={code="i4",size=4}, Uint32={code="I4",size=4}, Int64={code="i8",size=8}, Uint64={code="I8",size=8}, LuaInt={code="j",size=8}, UluaInt={code="J",size=8}, LuaNum={code="n",size=8}, Float32={code="f",size=4}, Float64={code="d",size=8}, String={code="z",size=-1} }, FixedTypes={ String={code="c",size=-1}, Int={code="i",size=-1}, Uint={code="I",size=-1} } }
+DataView.__index = DataView
+local function _ib(o,l,t) return((t.size<0 and true)or(o+(t.size-1)<=l))end
+local function _ef(big) return(big and DataView.EndBig)or DataView.EndLittle end
+function DataView.ArrayBuffer(length) return setmetatable({offset=1,length=length,blob=_strblob(length)},DataView)end
+function DataView.Wrap(blob) return setmetatable({offset=1,blob=blob,length=blob:len()},DataView)end
+function DataView:Buffer() return self.blob end
+function DataView:ByteLength() return self.length end
+function DataView:ByteOffset() return self.offset end
+function DataView:SubView(offset) return setmetatable({offset=offset,blob=self.blob,length=self.length},DataView)end
+for label,datatype in pairs(DataView.Types) do
+    DataView["Get"..label]=function(self,offset,endian) if _ib(offset,self.length,datatype) then local v=string.unpack(_ef(endian)..datatype.code,self.blob,self.offset+offset) return v end end
+    DataView["Set"..label]=function(self,offset,value,endian) if _ib(offset,self.length,datatype) then self.blob=self.blob:sub(1,self.offset+offset-1)..string.pack(_ef(endian)..datatype.code,value)..self.blob:sub(self.offset+offset+datatype.size) end end
+end
+
+local function playAmbientSpeechFromEntity(entity, soundRef, soundName, speechParams, speechLine)
+    local struct = DataView.ArrayBuffer(128)
+    local sName  = Citizen.InvokeNative(0xFA925AC00EB830B9, 10, "LITERAL_STRING", soundName, Citizen.ResultAsLong())
+    local sRef   = Citizen.InvokeNative(0xFA925AC00EB830B9, 10, "LITERAL_STRING", soundRef,  Citizen.ResultAsLong())
+    local params = GetHashKey(speechParams)
+    struct:SetInt64(0,  sName)
+    struct:SetInt64(8,  sRef)
+    struct:SetInt32(16, speechLine)
+    struct:SetInt64(24, params)
+    struct:SetInt32(32, 0)
+    struct:SetInt32(40, 1)
+    struct:SetInt32(48, 1)
+    Citizen.InvokeNative(0x8E04FEDD28D42462, entity, struct:Buffer())
+end
+
+AddEventHandler('game:playAmbientSpeech', function(entity, soundRef, soundName, speechParams, speechLine)
+    playAmbientSpeechFromEntity(entity, soundRef, soundName, speechParams, speechLine or 0)
+end)
+
+function getStateValue(entityId, key)
     if not entityId then
         return nil
     end

--- a/resources/game/src/client/exports.ts
+++ b/resources/game/src/client/exports.ts
@@ -268,6 +268,7 @@ const isPedFacingCoord: Game.isPedFacingCoord = (targetCoords, ped, toleranceDeg
   return gameManager.isPedFacingCoord(targetCoords, ped, toleranceDeg);
 };
 
+
 exports<'game'>('playerPed', playerPed);
 exports<'game'>('mountPed', mountPed);
 exports<'game'>('playerCoords', playerCoords);

--- a/resources/game/src/client/managers/game-manager.ts
+++ b/resources/game/src/client/managers/game-manager.ts
@@ -408,7 +408,11 @@ class GameManager {
     if (typeof hash === 'string') {
       hash = GetHashKey(hash);
     }
-    if (HasModelLoaded(hash) || !IsModelValid(hash)) {
+    if (HasModelLoaded(hash)) {
+      return;
+    }
+    if (!IsModelValid(hash)) {
+      console.warn(`[Game] loadModel: model hash ${hash} is not valid — ped will not spawn`);
       return;
     }
     return new Promise((resolve) => {
@@ -1134,29 +1138,6 @@ class GameManager {
     this.attachEntityToBoneIndex(attacher, GetEntityBoneIndexByName(attachee, boneName), attachee, offset, rotation);
   }
 
-  playAmbientSpeechFromEntity(
-    entity: number,
-    ref: string,
-    name: string,
-    speechParamsString: string,
-    speechLine: number,
-  ) {
-    const struct = new DataView(new ArrayBuffer(128));
-    const soundName = VarString(10, 'LITERAL_STRING', name);
-    const soundRef = VarString(10, 'LITERAL_STRING', ref);
-    const speechParams = GetHashKey(speechParamsString);
-
-    struct.setBigInt64(0, BigInt(soundName), true);
-    struct.setBigInt64(8, BigInt(soundRef), true);
-    struct.setInt32(16, speechLine, true);
-    struct.setBigInt64(24, BigInt(speechParams), true);
-    struct.setInt32(32, 0, true);
-    struct.setInt32(40, 1, true);
-    struct.setInt32(48, 1, true);
-    struct.setInt32(56, 1, true);
-
-    PlayPedAmbientSpeechNative(entity, struct);
-  }
 
   getEntityComponents(entity: number): number[] {
     const metaPedType = GetMetaPedType(entity);


### PR DESCRIPTION
This generic manager can be called client side to manage the lifecycle of NPCs owned by resources.

Features include:
- Spawning / Despawning
- Normal ped flags exposed as simple config like freeze, invincible, networked ...
- Ambient speech loop, allowing for more natural and immersive interactions with NPCs.
- Scripted routines, allowing for more curated execution of scenarios/animations/speeches that can be combined in a timed sequence.
    - these can be paused/resumed
- Event based reactions, allowing peds to react to typed Events of EventData. Includes triggering audio/speech queues + onReact() callback function to allow further code integration.

Speech related research came from https://github.com/femga/rdr3_discoveries/blob/master/audio/audio_banks/README.md, importing https://github.com/femga/rdr3_discoveries/blob/master/audio/audio_banks/audio_banks.lua (10MB) in size to this repo may be beneficial for discoverability / typing of audio bank dictionary and audio names.

```ts
const manager = PedManager().getInstance();

const ped = await manager.spawn('my-ped', {
    model: 'mp_m_m_bankclerk01_01',
    position: { x: -252.8, y: 764.2, z: 118.9, w: 90 },
    freeze: true,
    invincible: true,
    blockEvents: true,
    missionEntity: true,
    // Ambient speech fires on a random interval independently of the routine.
    speech: {
      ref: '0822_S_M_M_BANKCLERK_01_WHITE_01',
      names: ['HOWS_IT_GOING', 'WELCOME'],
      params: 'speech_params_standard',
      intervalMs: [15_000, 45_000],
    },
    // Routine loops through all step types as a demonstration:
    //   scenario — teller works at the counter
    //   anim     — does key unlock animation
    //   speech   — one-shot voiced line mid-routine
    //   wait     — brief pause before the next cycle
    routine: [
      { type: 'scenario', name: 'WORLD_HUMAN_VAL_BANKTELLER', duration: 10_000 },
      { type: 'anim',     dict: 'script_common@jail_cell@unlock@key', anim: 'action_mp_female', duration: 2_000 },
      { type: 'speech',   ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'UNAUTHORIZED_AREA', params: 'speech_params_force' },
      { type: 'wait',     ms: 2_000 },
    ],
    reactions: [
      // Teller reacts when they personally are attacked.
      {
        event: 'EVENT_ENTITY_DAMAGED',
        entityField: 'attacked',
        cooldownMs: 8_000,
        lines: [
          { ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'GENERIC_FRIGHTENED_HIGH', params: 'speech_params_force' },
          { ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'LAW_THREAT',  params: 'speech_params_force' },
        ],
      },
      // Teller reacts to any violence happening nearby (any entity damaged).
      {
        event: 'EVENT_SHOT_FIRED_BULLET_IMPACT',
        cooldownMs: 15_000,
        lines: [
          { ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'GET_AWAY_FROM_ME', params: 'speech_params_force_shouted' },
          { ref: '0822_S_M_M_BANKCLERK_01_WHITE_01', name: 'GENERIC_SHOCKED_MED',  params: 'speech_params_force_shouted' },
        ],
        onReact: (pedHandle, data) => {
          // e.g. trigger a flee animation, send a server event, update UI, etc.
          console.log(`ped ${pedHandle} was hit:`, data);
        },
      },
    ] satisfies PedReactionConfig[],
  });
```

Possible future improvements:
- deferring the routine animation to the existing code for handling animations in a common way.
- routine sets, allowing for more variety instead of a singular loop we could let developers define multiple routines which get chosen at random.
- ped clothing/character customization data.