### PR TITLE
feat(gametime): Add gametime resource to synchronize in-game time across networked clients. 

### DIFF
--- a/resources.cfg
+++ b/resources.cfg
@@ -29,6 +29,9 @@ ensure databindings
 ensure world
 ensure doors
 
+ensure weather
+ensure gametime
+
 ensure customization
 
 ensure ui
@@ -42,5 +45,3 @@ ensure stable
 
 ensure inventory
 ensure carrier-birds
-
-ensure weather

--- a/resources.cfg
+++ b/resources.cfg
@@ -29,7 +29,7 @@ ensure databindings
 ensure world
 ensure doors
 
-ensure weather
+#ensure weather
 ensure gametime
 
 ensure customization

--- a/resources.cfg
+++ b/resources.cfg
@@ -29,7 +29,7 @@ ensure databindings
 ensure world
 ensure doors
 
-#ensure weather
+ensure weather
 ensure gametime
 
 ensure customization

--- a/resources/[tools]/research/src/client/commands.ts
+++ b/resources/[tools]/research/src/client/commands.ts
@@ -109,33 +109,6 @@ RegisterCommand(
 );
 
 RegisterCommand(
-  'daytime',
-  (source: number, args: string[]) => {
-    const currentHour = GetClockHours();
-
-    const transitionTime = Math.round(lerp(1_000, 10_000, Math.abs(currentHour - 12) / 12));
-
-    console.log(currentHour, transitionTime);
-
-    NetworkClockTimeOverride(12, 0, 0, transitionTime, args[0] === 'true' || args[0] === '1');
-  },
-  false,
-);
-
-RegisterCommand(
-  'nighttime',
-  async (source: number, args: any[], rawCommand: string) => {
-    const currentHour = GetClockHours();
-
-    const transitionTime = Math.round(lerp(1_000, 5_000, currentHour / 12));
-    console.log(currentHour, transitionTime);
-
-    NetworkClockTimeOverride(0, 0, 0, transitionTime, args[0] === 'true' || args[0] === '1');
-  },
-  false,
-);
-
-RegisterCommand(
   'finalize',
   async (source: number, args: any[], rawCommand: string) => {
     // console.log({ source, args, rawCommand });

--- a/resources/gametime/fxmanifest.lua
+++ b/resources/gametime/fxmanifest.lua
@@ -1,0 +1,14 @@
+fx_version 'cerulean'
+games { 'rdr3' }
+rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
+version '1.0.0'
+
+lua54 'yes'
+
+server_scripts {
+  "build/server.js"
+}
+
+client_scripts {
+  "build/client.js"
+}

--- a/resources/gametime/package.json
+++ b/resources/gametime/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "gametime",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "CC-BY-NC-SA-4.0",
+  "scripts": {
+    "build": "rspack --mode production",
+    "watch": "rspack --mode development --watch",
+    "prettier": "prettier src/**/*.{ts,tsx} --write"
+  }
+}

--- a/resources/gametime/rspack.config.js
+++ b/resources/gametime/rspack.config.js
@@ -1,0 +1,3 @@
+const { clientServer } = require('../../rspack/rspack.options');
+
+module.exports = clientServer;

--- a/resources/gametime/src/client/client.ts
+++ b/resources/gametime/src/client/client.ts
@@ -1,30 +1,118 @@
 import { awaitServer, onServer } from '@lib/client';
 
 import type { GameTimeState } from '../shared/types';
+import {
+  MINUTES_PER_HOUR,
+  SECONDS_PER_MINUTE,
+  GAME_HOURS_PER_DAY
+} from '../shared/types'
 
-const GAME_MINUTES_PER_DAY = 24 * 60;
+const SECONDS_PER_DAY = GAME_HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE;
 
-function applyState(state: GameTimeState): void {
-  // Point the game's own clock at the given rate so it free-runs forward every
-  // frame on its own — no client-side ticking/polling needed between syncs.
-  SetMillisecondsPerGameMinute((state.dayLengthMinutes * 60 * 1000) / GAME_MINUTES_PER_DAY);
-  NetworkClockTimeOverride(state.hour, state.minute, state.second, state.transitionMs, false);
+let DEFAULT_GAMETIME_TICK_MS: number = 250;
+const TRANSITION_TICK_MS: number = 5;
+const MAX_TRANSITION_MS: number = 7500;
+
+const toDaySeconds = (hour: number, minute: number, second: number): number =>
+  hour * MINUTES_PER_HOUR * SECONDS_PER_MINUTE + minute * SECONDS_PER_MINUTE + second;
+
+const applyDaySeconds = (daySeconds: number): void => {
+  const wrapped = ((daySeconds % SECONDS_PER_DAY) + SECONDS_PER_DAY) % SECONDS_PER_DAY;
+  const hour = Math.floor(wrapped / (MINUTES_PER_HOUR * SECONDS_PER_MINUTE));
+  const minute = Math.floor(wrapped / SECONDS_PER_MINUTE) % MINUTES_PER_HOUR;
+  const second = Math.floor(wrapped) % SECONDS_PER_MINUTE;
+  SetClockTime(hour, minute, second);
+};
+
+let currentDaySeconds = toDaySeconds(6, 0, 0);
+
+// When a sync/getState arrives with transitionMs > 0, we lerp currentDaySeconds
+// toward the target over that duration instead of snapping to it immediately.
+let transition: { from: number; to: number; startedAt: number; durationMs: number } | null = null;
+
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+let lastTickAt: number = Date.now();
+
+// Runs the tick loop at `ms` — used to switch to a fast tick during a
+// transition so the lerp reads as smooth, then revert once it's done.
+const scheduleTick = (ms: number): void => {
+  if (tickHandle !== null) clearInterval(tickHandle);
+  lastTickAt = Date.now();
+  tickHandle = setInterval(tick, ms);
+};
+
+
+function tick(): void {
+  if (transition) {
+    const elapsed = Date.now() - transition.startedAt;
+    const t = Math.min(elapsed / transition.durationMs, 1);
+    currentDaySeconds = transition.from + (transition.to - transition.from) * t;
+    if (t >= 1) {
+      transition = null;
+      scheduleTick(DEFAULT_GAMETIME_TICK_MS);
+    }
+  } else {
+    // Elapsed-time based rather than a fixed per-tick increment, so drift or
+    // throttling in the underlying setInterval (CEF/NUI timer jitter is
+    // worse at short intervals) doesn't slow the clock down.
+    const now = Date.now();
+    const realElapsedMs = now - lastTickAt;
+    lastTickAt = now;
+    currentDaySeconds += (SECONDS_PER_MINUTE / DEFAULT_GAMETIME_TICK_MS) * realElapsedMs;
+  }
+  applyDaySeconds(currentDaySeconds);
 }
 
+const beginTransition = (state: GameTimeState): void => {
+  const target = toDaySeconds(state.hour, state.minute, state.second);
+
+  if (!state.transitionMs || state.transitionMs <= 0) {
+    transition = null;
+    currentDaySeconds = target;
+    applyDaySeconds(currentDaySeconds);
+    scheduleTick(DEFAULT_GAMETIME_TICK_MS);
+    return;
+  }
+
+  // Lerp along the shorter direction around the 24h wrap (e.g. 23:59 -> 00:01).
+  let delta = (target - currentDaySeconds) % SECONDS_PER_DAY;
+  if (delta > SECONDS_PER_DAY / 2) delta -= SECONDS_PER_DAY;
+  if (delta < -SECONDS_PER_DAY / 2) delta += SECONDS_PER_DAY;
+
+  const durationMs = Math.min(state.transitionMs, MAX_TRANSITION_MS);
+
+  transition = {
+    from: currentDaySeconds,
+    to: currentDaySeconds + delta,
+    startedAt: Date.now(),
+    durationMs
+  };
+
+  console.log(`gametime transition starting, lerping over ${durationMs}ms`);
+
+  // Tick fast for the duration of the transition so the lerp is smooth,
+  // independent of the (possibly much slower) steady-state tick rate.
+  scheduleTick(Math.min(TRANSITION_TICK_MS, DEFAULT_GAMETIME_TICK_MS));
+};
+
+scheduleTick(DEFAULT_GAMETIME_TICK_MS);
+
 // Periodic drift-correction and admin-triggered jumps both arrive as
-// gametime:sync — routine corrections carry transitionMs=0 (instant), jumps
+// gametime.sync — routine corrections carry transitionMs=0 (instant), jumps
 // carry a lerped transitionMs so the change animates.
-onServer('gametime:sync', (state: GameTimeState) => {
+onServer('gametime.sync', (state: GameTimeState) => {
   console.log('gametime sync', state)
-  applyState(state)
+  SetWeatherOwnedByNetwork(false);
+  DEFAULT_GAMETIME_TICK_MS = state.tickIntervalMs
+  beginTransition(state);
 });
 
 // Pull the current state on startup rather than waiting for the next periodic
 // broadcast (up to several minutes away) — covers both newly-joined players
 // and this resource being restarted while players are already connected.
-// awaitServer('gametime.getState').then(applyState);
-
 awaitServer('gametime.getState').then((state: GameTimeState) => {
   console.log('fetched gametime state', state)
-  applyState(state)
+  SetWeatherOwnedByNetwork(false);
+  DEFAULT_GAMETIME_TICK_MS = state.tickIntervalMs
+  beginTransition(state);
 });

--- a/resources/gametime/src/client/client.ts
+++ b/resources/gametime/src/client/client.ts
@@ -1,0 +1,30 @@
+import { awaitServer, onServer } from '@lib/client';
+
+import type { GameTimeState } from '../shared/types';
+
+const GAME_MINUTES_PER_DAY = 24 * 60;
+
+function applyState(state: GameTimeState): void {
+  // Point the game's own clock at the given rate so it free-runs forward every
+  // frame on its own — no client-side ticking/polling needed between syncs.
+  SetMillisecondsPerGameMinute((state.dayLengthMinutes * 60 * 1000) / GAME_MINUTES_PER_DAY);
+  NetworkClockTimeOverride(state.hour, state.minute, state.second, state.transitionMs, false);
+}
+
+// Periodic drift-correction and admin-triggered jumps both arrive as
+// gametime:sync — routine corrections carry transitionMs=0 (instant), jumps
+// carry a lerped transitionMs so the change animates.
+onServer('gametime:sync', (state: GameTimeState) => {
+  console.log('gametime sync', state)
+  applyState(state)
+});
+
+// Pull the current state on startup rather than waiting for the next periodic
+// broadcast (up to several minutes away) — covers both newly-joined players
+// and this resource being restarted while players are already connected.
+// awaitServer('gametime.getState').then(applyState);
+
+awaitServer('gametime.getState').then((state: GameTimeState) => {
+  console.log('fetched gametime state', state)
+  applyState(state)
+});

--- a/resources/gametime/src/client/tsconfig.json
+++ b/resources/gametime/src/client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.client.json",
+  "include": [
+    "./",
+    "../../../../types.d.ts",
+    "../../../*/rdr3-shared/types/**/*.d.ts",
+    "../../../**/src/types.d.ts",
+    "../../../**/src/client/types.d.ts"
+  ]
+}

--- a/resources/gametime/src/client/types.d.ts
+++ b/resources/gametime/src/client/types.d.ts
@@ -1,0 +1,13 @@
+// Client perspective - events received from various sources
+declare namespace ClientIn {
+  interface FromServer {
+    ['gametime:sync']: (state: import('../shared/types').GameTimeState) => void;
+  }
+}
+
+// Client perspective - RPC calls to various destinations
+declare namespace ClientRPC {
+  interface Server {
+    ['gametime.getState']: () => import('../shared/types').GameTimeState;
+  }
+}

--- a/resources/gametime/src/client/types.d.ts
+++ b/resources/gametime/src/client/types.d.ts
@@ -1,7 +1,7 @@
 // Client perspective - events received from various sources
 declare namespace ClientIn {
   interface FromServer {
-    ['gametime:sync']: (state: import('../shared/types').GameTimeState) => void;
+    ['gametime.sync']: (state: import('../shared/types').GameTimeState) => void;
   }
 }
 

--- a/resources/gametime/src/server/clock.ts
+++ b/resources/gametime/src/server/clock.ts
@@ -1,6 +1,15 @@
-import type { GameTimeState } from '../shared/types';
+import { emitClient, onClientCall } from '@lib/server';
+import { lerp } from '@lib/math';
 
-const SECONDS_PER_DAY = 24 * 60 * 60;
+import type { GameTimeState } from '../shared/types';
+import {
+  REAL_MINUTES_PER_DAY,
+  SECONDS_PER_DAY,
+  SECONDS_PER_MINUTE,
+  MILISECONDS_PER_SECOND,
+  GAME_HOURS_PER_DAY,
+  MINUTES_PER_HOUR,
+} from '../shared/types';
 
 /**
  * Authoritative virtual game clock. Advances hour/minute/second forward at a
@@ -8,13 +17,23 @@ const SECONDS_PER_DAY = 24 * 60 * 60;
  * client. Broadcasting the resulting state is the caller's responsibility.
  */
 export class GameClock {
+  private static instance: GameClock | null = null;
+
   private totalSeconds: number;
   private dayLengthMinutes: number;
   private tickIntervalId: ReturnType<typeof setInterval> | null = null;
+  private syncIntervalId: ReturnType<typeof setInterval> | null = null;
 
-  constructor(dayLengthMinutes: number, startHour = 6, startMinute = 0, startSecond = 0) {
+  private constructor(dayLengthMinutes: number, startHour = 6, startMinute = 0, startSecond = 0) {
     this.dayLengthMinutes = dayLengthMinutes;
     this.totalSeconds = startHour * 3600 + startMinute * 60 + startSecond;
+  }
+
+  public static getInstance(dayLengthMinutes?: number, startHour = 6, startMinute = 0, startSecond = 0): GameClock {
+    if (!GameClock.instance) {
+      GameClock.instance = new GameClock(dayLengthMinutes ?? REAL_MINUTES_PER_DAY, startHour, startMinute, startSecond);
+    }
+    return GameClock.instance;
   }
 
   /** Game-seconds that pass per real second, given the configured day length */
@@ -35,6 +54,54 @@ export class GameClock {
       clearInterval(this.tickIntervalId);
       this.tickIntervalId = null;
     }
+
+    if (this.syncIntervalId !== null) {
+      clearInterval(this.syncIntervalId);
+      this.syncIntervalId = null;
+    }
+  }
+
+  /** Wires up broadcasting, client pull, resource lifecycle, and the settime command. */
+  public init(syncIntervalMs: number): void {
+    this.start();
+
+    this.syncIntervalId = setInterval(() => this.broadcastState(), syncIntervalMs);
+
+    RegisterCommand(
+      'gametime:settime',
+      (_source: number, args: string[]) => {
+        const hour = Number(args[0]);
+        const minute = Number(args[1] ?? 0);
+
+        if (
+          !Number.isFinite(hour) ||
+          hour < 0 ||
+          hour > 23 ||
+          !Number.isFinite(minute) ||
+          minute < 0 ||
+          minute > 59
+        ) {
+          console.log('Usage: gametime:settime <hour 0-23> <minute 0-59>');
+          return;
+        }
+
+        const before = this.getState();
+        this.setTime(hour, minute, 0);
+
+        // Same lerp shape as the /daytime and /nighttime commands in the research tool —
+        // farther jumps get a longer, smoother transition, closer jumps snap faster.
+        const hourDelta = Math.abs(before.hour - hour);
+        const transitionMs = Math.round(lerp(1_000, 10_000, Math.min(hourDelta, 24 - hourDelta) / 12));
+
+        this.broadcastState(transitionMs);
+        console.log(`[GameTime] Jumping to ${hour}:${minute.toString().padStart(2, '0')} over ${transitionMs}ms`);
+      },
+      false,
+    );
+  }
+
+  public broadcastState(transitionMs: number = 0): void {
+    emitClient('gametime.sync', -1, { ...this.getState(), transitionMs });
   }
 
   public setDayLengthMinutes(minutes: number): void {
@@ -52,8 +119,14 @@ export class GameClock {
       hour: Math.floor(wholeSeconds / 3600),
       minute: Math.floor((wholeSeconds % 3600) / 60),
       second: wholeSeconds % 60,
-      dayLengthMinutes: this.dayLengthMinutes,
+      tickIntervalMs: this.calculateMsPerGameMinute(),
       transitionMs: 0,
     };
+  }
+
+  private calculateMsPerGameMinute(): number {
+    const totalRealMs: number = this.dayLengthMinutes * SECONDS_PER_MINUTE * MILISECONDS_PER_SECOND;
+    const totalGameMinutes: number = GAME_HOURS_PER_DAY * MINUTES_PER_HOUR;
+    return totalRealMs / totalGameMinutes;
   }
 }

--- a/resources/gametime/src/server/clock.ts
+++ b/resources/gametime/src/server/clock.ts
@@ -1,0 +1,59 @@
+import type { GameTimeState } from '../shared/types';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+/**
+ * Authoritative virtual game clock. Advances hour/minute/second forward at a
+ * configurable ratio of game-seconds per real second, independent of any
+ * client. Broadcasting the resulting state is the caller's responsibility.
+ */
+export class GameClock {
+  private totalSeconds: number;
+  private dayLengthMinutes: number;
+  private tickIntervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(dayLengthMinutes: number, startHour = 6, startMinute = 0, startSecond = 0) {
+    this.dayLengthMinutes = dayLengthMinutes;
+    this.totalSeconds = startHour * 3600 + startMinute * 60 + startSecond;
+  }
+
+  /** Game-seconds that pass per real second, given the configured day length */
+  private get gameSecondsPerRealSecond(): number {
+    return SECONDS_PER_DAY / (this.dayLengthMinutes * 60);
+  }
+
+  public start(): void {
+    if (this.tickIntervalId !== null) return;
+
+    this.tickIntervalId = setInterval(() => {
+      this.totalSeconds = (this.totalSeconds + this.gameSecondsPerRealSecond) % SECONDS_PER_DAY;
+    }, 1000);
+  }
+
+  public stop(): void {
+    if (this.tickIntervalId !== null) {
+      clearInterval(this.tickIntervalId);
+      this.tickIntervalId = null;
+    }
+  }
+
+  public setDayLengthMinutes(minutes: number): void {
+    this.dayLengthMinutes = minutes;
+  }
+
+  /** Set the clock to a specific time immediately (no transition — that's a client concern) */
+  public setTime(hour: number, minute: number, second = 0): void {
+    this.totalSeconds = ((hour * 3600 + minute * 60 + second) % SECONDS_PER_DAY + SECONDS_PER_DAY) % SECONDS_PER_DAY;
+  }
+
+  public getState(): GameTimeState {
+    const wholeSeconds = Math.floor(this.totalSeconds);
+    return {
+      hour: Math.floor(wholeSeconds / 3600),
+      minute: Math.floor((wholeSeconds % 3600) / 60),
+      second: wholeSeconds % 60,
+      dayLengthMinutes: this.dayLengthMinutes,
+      transitionMs: 0,
+    };
+  }
+}

--- a/resources/gametime/src/server/server.ts
+++ b/resources/gametime/src/server/server.ts
@@ -1,0 +1,57 @@
+import { emitClient, onClientCall } from '@lib/server';
+import { lerp } from '@lib/math';
+
+import { GAMETIME_EVENTS } from '../shared/types';
+import { GameClock } from './clock';
+
+// How long an in-game day (24 hours) should take in real time
+const DAY_LENGTH_MINUTES = Number(GetConvar('GAMETIME_DAY_LENGTH_MINUTES', '60'));
+// Drift-correction only — the client's own clock free-runs between syncs via
+// SetMillisecondsPerGameMinute, so this can be infrequent.
+const SYNC_INTERVAL_MS = Number(GetConvar('GAMETIME_SYNC_INTERVAL_MS', String(5 * 60 * 1000)));
+
+const clock = new GameClock(DAY_LENGTH_MINUTES);
+
+function broadcastState(transitionMs: number = 0): void {
+  emitClient(GAMETIME_EVENTS.SYNC, -1, { ...clock.getState(), transitionMs });
+}
+
+clock.start();
+setInterval(() => broadcastState(), SYNC_INTERVAL_MS);
+
+// Newly-joined players (and clients whose own resource just (re)started) pull
+// their initial state directly instead of waiting on the next periodic sync,
+// which can be minutes away. This also covers this resource restarting while
+// players are already connected — client.ts re-runs the same pull on load.
+onClientCall('gametime.getState', () => ({ ...clock.getState(), transitionMs: 0 }));
+
+on('onResourceStop', (resourceName: string) => {
+  if (resourceName === GetCurrentResourceName()) {
+    clock.stop();
+  }
+});
+
+RegisterCommand(
+  'gametime:settime',
+  (_source: number, args: string[]) => {
+    const hour = Number(args[0]);
+    const minute = Number(args[1] ?? 0);
+
+    if (!Number.isFinite(hour) || hour < 0 || hour > 23 || !Number.isFinite(minute) || minute < 0 || minute > 59) {
+      console.log('Usage: gametime:settime <hour 0-23> <minute 0-59>');
+      return;
+    }
+
+    const before = clock.getState();
+    clock.setTime(hour, minute, 0);
+
+    // Same lerp shape as the /daytime and /nighttime commands in the research tool —
+    // farther jumps get a longer, smoother transition, closer jumps snap faster.
+    const hourDelta = Math.abs(before.hour - hour);
+    const transitionMs = Math.round(lerp(1_000, 10_000, Math.min(hourDelta, 24 - hourDelta) / 12));
+
+    broadcastState(transitionMs);
+    console.log(`[GameTime] Jumping to ${hour}:${minute.toString().padStart(2, '0')} over ${transitionMs}ms`);
+  },
+  false,
+);

--- a/resources/gametime/src/server/server.ts
+++ b/resources/gametime/src/server/server.ts
@@ -1,57 +1,25 @@
-import { emitClient, onClientCall } from '@lib/server';
-import { lerp } from '@lib/math';
-
-import { GAMETIME_EVENTS } from '../shared/types';
+import { onClientCall } from '@lib/server';
 import { GameClock } from './clock';
 
 // How long an in-game day (24 hours) should take in real time
-const DAY_LENGTH_MINUTES = Number(GetConvar('GAMETIME_DAY_LENGTH_MINUTES', '60'));
+const DAY_LENGTH_MINUTES = Number(GetConvar('GAMETIME_DAY_LENGTH_MINUTES', '1'));
+
 // Drift-correction only — the client's own clock free-runs between syncs via
 // SetMillisecondsPerGameMinute, so this can be infrequent.
+// Default 5 minutes
 const SYNC_INTERVAL_MS = Number(GetConvar('GAMETIME_SYNC_INTERVAL_MS', String(5 * 60 * 1000)));
-
-const clock = new GameClock(DAY_LENGTH_MINUTES);
-
-function broadcastState(transitionMs: number = 0): void {
-  emitClient(GAMETIME_EVENTS.SYNC, -1, { ...clock.getState(), transitionMs });
-}
-
-clock.start();
-setInterval(() => broadcastState(), SYNC_INTERVAL_MS);
 
 // Newly-joined players (and clients whose own resource just (re)started) pull
 // their initial state directly instead of waiting on the next periodic sync,
 // which can be minutes away. This also covers this resource restarting while
 // players are already connected — client.ts re-runs the same pull on load.
-onClientCall('gametime.getState', () => ({ ...clock.getState(), transitionMs: 0 }));
+let gc = GameClock.getInstance(DAY_LENGTH_MINUTES);
+gc.init(SYNC_INTERVAL_MS);
+
+onClientCall('gametime.getState', () => ({ ...gc.getState(), transitionMs: 0 }));
 
 on('onResourceStop', (resourceName: string) => {
   if (resourceName === GetCurrentResourceName()) {
-    clock.stop();
+    gc.stop();
   }
 });
-
-RegisterCommand(
-  'gametime:settime',
-  (_source: number, args: string[]) => {
-    const hour = Number(args[0]);
-    const minute = Number(args[1] ?? 0);
-
-    if (!Number.isFinite(hour) || hour < 0 || hour > 23 || !Number.isFinite(minute) || minute < 0 || minute > 59) {
-      console.log('Usage: gametime:settime <hour 0-23> <minute 0-59>');
-      return;
-    }
-
-    const before = clock.getState();
-    clock.setTime(hour, minute, 0);
-
-    // Same lerp shape as the /daytime and /nighttime commands in the research tool —
-    // farther jumps get a longer, smoother transition, closer jumps snap faster.
-    const hourDelta = Math.abs(before.hour - hour);
-    const transitionMs = Math.round(lerp(1_000, 10_000, Math.min(hourDelta, 24 - hourDelta) / 12));
-
-    broadcastState(transitionMs);
-    console.log(`[GameTime] Jumping to ${hour}:${minute.toString().padStart(2, '0')} over ${transitionMs}ms`);
-  },
-  false,
-);

--- a/resources/gametime/src/server/server.ts
+++ b/resources/gametime/src/server/server.ts
@@ -2,7 +2,7 @@ import { onClientCall } from '@lib/server';
 import { GameClock } from './clock';
 
 // How long an in-game day (24 hours) should take in real time
-const DAY_LENGTH_MINUTES = Number(GetConvar('GAMETIME_DAY_LENGTH_MINUTES', '1'));
+const DAY_LENGTH_MINUTES = Number(GetConvar('GAMETIME_DAY_LENGTH_MINUTES', '30'));
 
 // Drift-correction only — the client's own clock free-runs between syncs via
 // SetMillisecondsPerGameMinute, so this can be infrequent.

--- a/resources/gametime/src/server/tsconfig.json
+++ b/resources/gametime/src/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.server.json",
+  "include": [
+    "./",
+    "../../../../types.d.ts",
+    "../../../../env.d.ts",
+    "../../../../socket/src/types.d.ts",
+    "../../../../socket/src/types/*.d.ts",
+    "../../../**/src/types.d.ts",
+    "../../../**/src/server/types.d.ts"
+  ]
+}

--- a/resources/gametime/src/server/types.d.ts
+++ b/resources/gametime/src/server/types.d.ts
@@ -1,0 +1,13 @@
+// Server perspective - events sent to various destinations
+declare namespace ServerOut {
+  interface ToClient {
+    ['gametime:sync']: (state: import('../shared/types').GameTimeState) => void;
+  }
+}
+
+// Server perspective - RPC calls from client
+declare namespace ServerRPC {
+  interface Client {
+    ['gametime.getState']: () => import('../shared/types').GameTimeState;
+  }
+}

--- a/resources/gametime/src/server/types.d.ts
+++ b/resources/gametime/src/server/types.d.ts
@@ -1,7 +1,7 @@
 // Server perspective - events sent to various destinations
 declare namespace ServerOut {
   interface ToClient {
-    ['gametime:sync']: (state: import('../shared/types').GameTimeState) => void;
+    ['gametime.sync']: (state: import('../shared/types').GameTimeState) => void;
   }
 }
 

--- a/resources/gametime/src/shared/types.ts
+++ b/resources/gametime/src/shared/types.ts
@@ -8,11 +8,13 @@ export interface GameTimeState {
   hour: number;
   minute: number;
   second: number;
-  dayLengthMinutes: number;
-  transitionMs: number
+  tickIntervalMs: number;
+  transitionMs: number;
 }
 
-export const GAMETIME_EVENTS = {
-  /** Routine periodic broadcast — clients snap/correct with no transition */
-  SYNC: 'gametime:sync',
-} as const;
+export const SECONDS_PER_DAY = 24 * 60 * 60;
+export const REAL_MINUTES_PER_DAY: number = 15;
+export const GAME_HOURS_PER_DAY: number = 24;
+export const MINUTES_PER_HOUR: number = 60;
+export const SECONDS_PER_MINUTE: number = 60;
+export const MILISECONDS_PER_SECOND: number = 1000;

--- a/resources/gametime/src/shared/types.ts
+++ b/resources/gametime/src/shared/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared type definitions for the gametime system
+ * Used across both client and server
+ */
+
+/** Authoritative game clock state, broadcast from server to clients */
+export interface GameTimeState {
+  hour: number;
+  minute: number;
+  second: number;
+  dayLengthMinutes: number;
+  transitionMs: number
+}
+
+export const GAMETIME_EVENTS = {
+  /** Routine periodic broadcast — clients snap/correct with no transition */
+  SYNC: 'gametime:sync',
+} as const;

--- a/resources/weather/src/client/client.ts
+++ b/resources/weather/src/client/client.ts
@@ -1,5 +1,4 @@
 import { PVGame } from '@lib/client';
-import { Delay } from '@lib/functions';
 
 import {
   WEATHER_COMPATIBILITY,
@@ -12,16 +11,7 @@ import weatherManager from './managers/weather';
 import './test';
 
 (async () => {
-  const [h, m, s] = NetworkGetGlobalMultiplayerClock();
-  console.log(`Initial multiplayer clock time: ${h}:${m}:${s}`);
-  const hours = GetClockHours();
-  const minutes = GetClockMinutes();
-  const seconds = GetClockSeconds();
-  console.log(`SetClockTime(${hours}, ${minutes}, ${seconds})`);
-  await Delay(1);
   SetWeatherOwnedByNetwork(false);
-  await Delay(1);
-  SetClockTime(hours, minutes, seconds);
 })();
 
 setInterval(() => {


### PR DESCRIPTION
As mentioned on stream the `weather` resource doesn't manage network time, it did attempt a rudimentary set and forget (now removed) for testing of the weather resource across networked clients.

### How this works
On connection (or resource restart) clients await `gametime.getState` to fetch the initial time from the server.

The server runs a virtual implementation of an authoritative clock, maintaining an internal reference of time elapsed in the context of in-game hours and how they relate to real-world hours. This allows us to easily configure things like, 24hours in game equates to 60 minutes in real time.

Every 5 minutes, the server will emit the current virtual clock time via `clock.getState()`. This is not lerp'd as it should only adjust for marginal time drift between server/clients.

There is an administrative command to jump to specific times `gametime:settime hh mm` via server console. This time jump is lerp'd, which configures a dynamic transition in milliseconds so that it is a visually pleasant transition in comparison to a hard snap.

- convar `GAMETIME_DAY_LENGTH_MINUTES` (default `30`) allows for adjusting time in real minutes for 24hrs to cycle in game.
- convar `GAMETIME_SYNC_INTERVAL_MS` (default 5 minutes) defines the interval at which regular updates are broadcast to all clients to keep them in roughly sync without drifting too much - shouldn't happen, more a stop-gap in case it does.

**UPDATE:**
In https://github.com/spAnser/pioneer-village/pull/18/commits/45ca5ca88272dd51c8e8e4cc28233b35658bd78b we re-enable the weather resource and move the `gametime` resource off the network-clock APIs entirely, working around the engine bug described in detail below.

Since `NetworkClockTimeOverride()` silently stops working whenever `SetWeatherOwnedByNetwork(false)` is set (they share the same underlying `IsApplyingMultiplayerGlobalClockAndWeather` flag), the client now drives time locally via `SetClockTime()`, ticking forward each frame using elapsed real time and its own client-side lerp implementation for smooth transitions (since the native lerp tied to `NetworkClockTimeOverride` is no longer usable).

Server-side, `GameClock` class becomes a singleton with its own `init()` that wires up the broadcast interval and the `gametime:settime` command internally, and the state payload now carries `tickIntervalMs` (derived from day length) instead of raw `dayLengthMinutes`, letting the client compute its own per-tick advance. Weather is explicitly disabled on the client whenever gametime state is applied, ensuring the two resources no longer fight over that shared engine flag.

---

### ~Why is weather now disabled?~ changed approach, weather remains enabled.

<details>
<summary>details of weather <> time relationship in here...</summary>
In the weather resource we set `SetWeatherOwnedByNetwork(false);` as we wanted to manually manage the weather state per-client based on the grid/biome approach with transitioning edges. 

When introducing `gametime` resource, we need to set `NetworkClockTimeOverride()` on the client, however this doesn't work when the `weather` resource is running. After a bit of painful debugging on both resource code, I've mapped this back to either a bug in the Cfx native implementation hook, and or the underlying RAGE engine doesn't distinguish between the two.

In both the RDR3 and Five weather native implementations (WeatherNatives.cpp), `g_weatherNetFlag` (the boolean flag toggled by `SetWeatherOwnedByNetwork`) is a memory pointer discovered via pattern-scanning, and the comment in the RDR3 file explicitly documents its real identity from the game's own symbol table

```
// IsApplyingMultiplayerGlobalClockAndWeather
static bool* g_weatherNetFlag;
```

That comment references the decompiled game function `_getIsApplyingMultiplayerGlobalClockAndWeather` (confirmed present in the game's own symbol dump at `/citizenfx/fivem/code/tools/dbg/dump_1436_31.txt:174160`).

This is not two independent flags, it's the same single game-engine flag governing both systems. R* built a single boolean, `IsApplyingMultiplayerGlobalClockAndWeather`, that the native game code checks to decide whether to accept both network-driven weather updates and network-driven clock-time updates

So when you call:

```SetWeatherOwnedByNetwork(false);```

you're not just disabling network-owned weather, you're flipping `IsApplyingMultiplayerGlobalClockAndWeather` to false, which also tells the game to stop applying multiplayer-synced clock time.

That's exactly why `NetworkClockTimeOverride()` (which relies on the network clock being applied) stops working: the underlying game logic that would consume/apply the overridden network clock value is gated by this same flag that `SetWeatherOwnedByNetwork(false)` just turned off.

If resolving the above isn't possible (I'm currently installing Ghidra to find out), we should be able to fall back with `SetClockTime()` however that would require calling it frequently, eg every 1s or so to manually progress the time client-side which obviously has some performance overhead.

</details>

