### PR TITLE
fix(weather): various weather fixes

### DIFF
--- a/resources/weather/fxmanifest.lua
+++ b/resources/weather/fxmanifest.lua
@@ -5,6 +5,10 @@ version '1.0.0'
 
 lua54 'yes'
 
+server_scripts {
+  "build/server.js",
+}
+
 client_scripts {
   "@rdr3-shared/client/rdr3_natives.js",
   "build/client.js",

--- a/resources/weather/rspack.config.js
+++ b/resources/weather/rspack.config.js
@@ -1,3 +1,3 @@
-const { client } = require('../../rspack/rspack.options');
+const { clientServer } = require('../../rspack/rspack.options');
 
-module.exports = client;
+module.exports = clientServer;

--- a/resources/weather/src/client/managers/weather.ts
+++ b/resources/weather/src/client/managers/weather.ts
@@ -109,6 +109,8 @@ export class ClientWeatherManager {
       if (weather) {
         console.log(`[Weather] Global override set to ${weather}`);
         const weatherType = weather as WeatherType;
+        this.setAllCellsToWeatherType(weatherType);
+        this.resetPlayerStatesToWeather(weatherType);
         this.transitionToWeather(weatherType, 0.0);
       } else {
         console.log('[Weather] Global override removed');
@@ -1110,6 +1112,22 @@ export class ClientWeatherManager {
 
   public getWeatherGrid(): BiomeWeatherGrid {
     return this.weatherGrid;
+  }
+
+  /**
+   * Reset all tracked players' transition state to settled at the given
+   * weather, clearing any in-flight approach/cross so a global override
+   * isn't fought by a stale transition target.
+   */
+  private resetPlayerStatesToWeather(weatherType: WeatherType): void {
+    for (const playerState of this.playerWeatherStates.values()) {
+      playerState.currentWeather = weatherType;
+      playerState.targetWeather = null;
+      playerState.targetNeighborCell = null;
+      playerState.previousCell = null;
+      playerState.transitionPhase = 'settled';
+      playerState.transitionPercent = 0.0;
+    }
   }
 
   public setAllCellsToWeatherType(weatherType: WeatherType): void {

--- a/resources/weather/src/server/server.ts
+++ b/resources/weather/src/server/server.ts
@@ -1,0 +1,104 @@
+import { awaitSocket } from '@lib/server';
+
+RegisterCommand(
+  'weather:grid-state',
+  async () => {
+    try {
+      const result = await awaitSocket('weather.admin.get-grid-state');
+      console.log(`[Weather] frozen=${result.frozen} globalOverride=${result.globalOverride ?? 'none'}`);
+      console.log(`[Weather] grid size: ${result.grid.length}x${result.grid[0]?.length ?? 0}`);
+    } catch (error) {
+      console.log('[Weather] Failed to get grid state:', error);
+    }
+  },
+  true,
+);
+
+RegisterCommand(
+  'weather:set-biome',
+  async (source: number, args: string[]) => {
+    const [biome, weather] = args;
+    if (!biome || !weather) {
+      console.log('Usage: weather:set-biome <biome> <weather>');
+      return;
+    }
+
+    try {
+      const result = await awaitSocket('weather.admin.set-biome-weather', biome, weather);
+      if (result.success) {
+        console.log(`[Weather] Updated ${result.updatedCount ?? 0} cell(s) in biome ${biome} to ${weather}`);
+      } else {
+        console.log('[Weather] Failed to set biome weather:', result.error);
+      }
+    } catch (error) {
+      console.log('[Weather] Failed to set biome weather:', error);
+    }
+  },
+  true,
+);
+
+RegisterCommand(
+  'weather:regenerate-grid',
+  async (source: number, args: string[]) => {
+    const seedArg = args[0];
+    const seed = seedArg !== undefined ? Number(seedArg) : undefined;
+    if (seedArg !== undefined && Number.isNaN(seed)) {
+      console.log('Usage: weather:regenerate-grid [seed]');
+      return;
+    }
+
+    try {
+      const result = await awaitSocket('weather.admin.regenerate-grid', seed);
+      if (result.success) {
+        console.log('[Weather] Grid regenerated');
+      } else {
+        console.log('[Weather] Failed to regenerate grid:', result.error);
+      }
+    } catch (error) {
+      console.log('[Weather] Failed to regenerate grid:', error);
+    }
+  },
+  true,
+);
+
+RegisterCommand(
+  'weather:freeze',
+  async (source: number, args: string[]) => {
+    const value = args[0]?.toLowerCase();
+    if (value !== 'true' && value !== 'false') {
+      console.log('Usage: weather:freeze <true|false>');
+      return;
+    }
+
+    try {
+      const result = await awaitSocket('weather.admin.freeze-weather', value === 'true');
+      if (result.success) {
+        console.log(`[Weather] Weather ${value === 'true' ? 'frozen' : 'unfrozen'}`);
+      } else {
+        console.log('[Weather] Failed to freeze weather:', result.error);
+      }
+    } catch (error) {
+      console.log('[Weather] Failed to freeze weather:', error);
+    }
+  },
+  true,
+);
+
+RegisterCommand(
+  'weather:force-global',
+  async (source: number, args: string[]) => {
+    const weather = args[0]?.toUpperCase();
+
+    try {
+      const result = await awaitSocket('weather.admin.force-global', weather ?? null);
+      if (result.success) {
+        console.log(weather ? `[Weather] Forced global weather to ${weather}` : '[Weather] Cleared global weather override');
+      } else {
+        console.log('[Weather] Failed to force global weather:', result.error);
+      }
+    } catch (error) {
+      console.log('[Weather] Failed to force global weather:', error);
+    }
+  },
+  true,
+);

--- a/resources/weather/src/server/tsconfig.json
+++ b/resources/weather/src/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.server.json",
+  "include": [
+    "./",
+    "../../../../types.d.ts",
+    "../../../../env.d.ts",
+    "../../../../socket/src/types.d.ts",
+    "../../../../socket/src/types/*.d.ts",
+    "../../../**/src/types.d.ts",
+    "../../../**/src/server/types.d.ts"
+  ]
+}

--- a/socket/src/controllers/weather.ts
+++ b/socket/src/controllers/weather.ts
@@ -1,6 +1,78 @@
-import { logInfoC } from '../helpers';
-import weatherManager, { toBiomeType, toWeatherType, BiomeType } from '../managers/weather';
-import { userNamespace } from '../server';
+import { logInfoC, logInfoS } from '../helpers';
+import weatherManager, { toBiomeType, toWeatherType, BiomeType, GridCell } from '../managers/weather';
+import { serverNamespace, userNamespace } from '../server';
+
+const getGridState = (cb: (result: { grid: GridCell[][]; frozen: boolean; globalOverride: string | null; }) => void = () => {}) => {
+  cb({
+    grid: weatherManager.getBiomeWeatherGrid().getGrid(),
+    frozen: weatherManager.isWeatherFrozen(),
+    globalOverride: weatherManager.getGlobalWeatherOverride(),
+  });
+};
+
+const setBiomeWeather = (biome: string, weather: string, cb: (result: { success: boolean; updatedCount?: number; error?: string; }) => void = () => {}) => {
+  const biomeType = toBiomeType(biome);
+  const weatherType = toWeatherType(weather);
+
+  if (!biomeType) {
+    cb({ success: false, error: `Invalid biome type: ${biome}` });
+    return;
+  }
+
+  if (!weatherType) {
+    cb({ success: false, error: `Invalid weather type: ${weather}` });
+    return;
+  }
+
+  const updatedCount = weatherManager.getBiomeWeatherGrid().overrideBiomeWeather(biomeType, weatherType);
+
+  if (updatedCount > 0) {
+    const grid = weatherManager.getBiomeWeatherGrid().getGrid();
+    userNamespace.emit('__client__', 'weather.grid-update', grid);
+  }
+
+  cb({ success: updatedCount > 0, updatedCount });
+};
+
+const regenerateGrid = (seed: number | undefined, cb: (result: { success: boolean; error?: string; }) => void = () => {}) => {
+  if (seed !== undefined && !Number.isFinite(seed)) {
+    cb({ success: false, error: 'Seed must be a finite number' });
+    return;
+  }
+
+  weatherManager.regenerateGrid(seed);
+
+  const grid = weatherManager.getBiomeWeatherGrid().getGrid();
+  userNamespace.emit('__client__', 'weather.grid-update', grid);
+
+  cb({ success: true });
+};
+
+const freezeWeather = (frozen: boolean, cb: (result: { success: boolean; error?: string; }) => void = () => {}) => {
+  weatherManager.freezeWeather(frozen);
+
+  userNamespace.emit('__client__', 'weather.freeze-state', frozen);
+
+  cb({ success: true });
+};
+
+const forceGlobal = (weather: string | null, cb: (result: { success: boolean; error?: string; }) => void = () => {}) => {
+  let weatherType = null;
+
+  if (weather !== null) {
+    weatherType = toWeatherType(weather);
+    if (!weatherType) {
+      cb({ success: false, error: `Invalid weather type: ${weather}` });
+      return;
+    }
+  }
+
+  weatherManager.forceGlobalWeather(weatherType);
+
+  userNamespace.emit('__client__', 'weather.global-override', weatherType);
+
+  cb({ success: true });
+};
 
 export default () => {
   weatherManager.initialize();
@@ -21,76 +93,20 @@ export default () => {
       cb({ grid: weatherManager.getBiomeWeatherGrid().getGrid() });
     });
 
-    socket.on('weather.admin.get-grid-state', (cb = () => {}) => {
-      cb({
-        grid: weatherManager.getBiomeWeatherGrid().getGrid(),
-        frozen: weatherManager.isWeatherFrozen(),
-        globalOverride: weatherManager.getGlobalWeatherOverride(),
-      });
-    });
+    socket.on('weather.admin.get-grid-state', getGridState);
+    socket.on('weather.admin.set-biome-weather', setBiomeWeather);
+    socket.on('weather.admin.regenerate-grid', regenerateGrid);
+    socket.on('weather.admin.freeze-weather', freezeWeather);
+    socket.on('weather.admin.force-global', forceGlobal);
+  });
 
-    socket.on('weather.admin.set-biome-weather', (biome: string, weather: string, cb = () => {}) => {
-      const biomeType = toBiomeType(biome);
-      const weatherType = toWeatherType(weather);
+  serverNamespace.on('connection', (socket) => {
+    logInfoS('[Weather]', 'Game server connected');
 
-      if (!biomeType) {
-        cb({ success: false, error: `Invalid biome type: ${biome}` });
-        return;
-      }
-
-      if (!weatherType) {
-        cb({ success: false, error: `Invalid weather type: ${weather}` });
-        return;
-      }
-
-      const updatedCount = weatherManager.getBiomeWeatherGrid().overrideBiomeWeather(biomeType, weatherType);
-
-      if (updatedCount > 0) {
-        const grid = weatherManager.getBiomeWeatherGrid().getGrid();
-        userNamespace.emit('__client__', 'weather.grid-update', grid);
-      }
-
-      cb({ success: updatedCount > 0, updatedCount });
-    });
-
-    socket.on('weather.admin.regenerate-grid', (seed: number | undefined, cb = () => {}) => {
-      if (seed !== undefined && !Number.isFinite(seed)) {
-        cb({ success: false, error: 'Seed must be a finite number' });
-        return;
-      }
-
-      weatherManager.regenerateGrid(seed);
-
-      const grid = weatherManager.getBiomeWeatherGrid().getGrid();
-      userNamespace.emit('__client__', 'weather.grid-update', grid);
-
-      cb({ success: true });
-    });
-
-    socket.on('weather.admin.freeze-weather', (frozen: boolean, cb = () => {}) => {
-      weatherManager.freezeWeather(frozen);
-
-      userNamespace.emit('__client__', 'weather.freeze-state', frozen);
-
-      cb({ success: true });
-    });
-
-    socket.on('weather.admin.force-global', (weather: string | null, cb = () => {}) => {
-      let weatherType = null;
-
-      if (weather !== null) {
-        weatherType = toWeatherType(weather);
-        if (!weatherType) {
-          cb({ success: false, error: `Invalid weather type: ${weather}` });
-          return;
-        }
-      }
-
-      weatherManager.forceGlobalWeather(weatherType);
-
-      userNamespace.emit('__client__', 'weather.global-override', weatherType);
-
-      cb({ success: true });
-    });
+    socket.on('weather.admin.get-grid-state', getGridState);
+    socket.on('weather.admin.set-biome-weather', setBiomeWeather);
+    socket.on('weather.admin.regenerate-grid', regenerateGrid);
+    socket.on('weather.admin.freeze-weather', freezeWeather);
+    socket.on('weather.admin.force-global', forceGlobal);
   });
 };

--- a/socket/src/types/weather.d.ts
+++ b/socket/src/types/weather.d.ts
@@ -8,6 +8,14 @@ declare namespace SocketIn {
     ['weather.admin.freeze-weather']: (frozen: boolean, callback: (result: { success: boolean; error?: string; }) => void) => void;
     ['weather.admin.force-global']: (weather: string | null, callback: (result: { success: boolean; error?: string; }) => void) => void;
   }
+
+  interface FromGameServer {
+    ['weather.admin.get-grid-state']: (callback: (result: { grid: { x: number; y: number; weather: string; variant: string | null; biome: string; rainRate: number; }[][]; frozen: boolean; globalOverride: string | null; }) => void) => void;
+    ['weather.admin.set-biome-weather']: (biome: string, weather: string, callback: (result: { success: boolean; updatedCount?: number; error?: string; }) => void) => void;
+    ['weather.admin.regenerate-grid']: (seed: number | undefined, callback: (result: { success: boolean; error?: string; }) => void) => void;
+    ['weather.admin.freeze-weather']: (frozen: boolean, callback: (result: { success: boolean; error?: string; }) => void) => void;
+    ['weather.admin.force-global']: (weather: string | null, callback: (result: { success: boolean; error?: string; }) => void) => void;
+  }
 }
 
 // Socket perspective - what the socket server sends


### PR DESCRIPTION
When debugging the `weather` <> `gametime` bug (see https://github.com/spAnser/pioneer-village/pull/18) for Network weather + time I noticed some functionality in weather resource wasn't working as intended.

- Expose the 'admin' functions to the game server + add `weather:*` commands, the same `weather.admin.*` events are now registered on both the game <> socket namespace as well as client <> socket.
- Fix `weather.global-override` not updating all cells, currently there is transitive fighting due to states being out of sync for any players considered 'in-transition'.