### PR TITLE
fix(lantern): make lantern oil color change sync'd across network

### DIFF
--- a/lib/client/index.ts
+++ b/lib/client/index.ts
@@ -5,6 +5,7 @@ export * from './resources';
 export * from './game';
 export * from './events';
 export { PedManager } from './ped-manager';
+export { setLanternOilColor, initLanternLightSync } from './lantern-light';
 export type { PedConfig, PedSpeechConfig, RoutineStep, PedReactionConfig, ReactionSpeech } from './ped-manager';
 
 // @ts-ignore

--- a/lib/client/lantern-light.ts
+++ b/lib/client/lantern-light.ts
@@ -1,0 +1,66 @@
+import { AttachPoint } from '@lib/flags';
+
+const LANTERN_OIL_COLOR_STATE_KEY = 'lanternOilColor';
+
+type LanternOilColorState = {
+  attachPoint: AttachPoint;
+  oilColor: [number, number, number];
+};
+
+export function setLanternOilColor(ped: number, attachPoint: AttachPoint, oilColor: [number, number, number]) {
+  const lanternEntity = GetCurrentPedWeaponEntityIndex(ped, attachPoint);
+  if (lanternEntity) {
+    SetLightsColorForEntity(lanternEntity, oilColor[0], oilColor[1], oilColor[2]);
+  }
+
+  // console.log('[lantern-light] setLanternOilColor', {
+  //   ped,
+  //   attachPoint,
+  //   oilColor,
+  //   isNetworked: NetworkGetEntityIsNetworked(ped),
+  //   netId: NetworkGetEntityIsNetworked(ped) ? NetworkGetNetworkIdFromEntity(ped) : undefined,
+  // });
+
+  if (NetworkGetEntityIsNetworked(ped)) {
+    const state: LanternOilColorState = { attachPoint, oilColor };
+    Entity(ped).state.set(LANTERN_OIL_COLOR_STATE_KEY, state, true);
+    // console.log('[lantern-light] state.set applied, readback=', Entity(ped).state[LANTERN_OIL_COLOR_STATE_KEY]);
+  }
+}
+
+let initialized = false;
+
+export function initLanternLightSync() {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+
+  // console.log('[lantern-light] initLanternLightSync registering handler, resource=', GetCurrentResourceName());
+
+  AddStateBagChangeHandler(LANTERN_OIL_COLOR_STATE_KEY, '', (bagName: string, _key: string, value: LanternOilColorState | undefined) => {
+    // console.log('[lantern-light] state bag change fired', { bagName, value });
+
+    if (!value) {
+      // console.log('[lantern-light] no value, skipping');
+      return;
+    }
+
+    const ped = GetEntityFromStateBagName(bagName);
+    // console.log('[lantern-light] resolved ped from bag', { bagName, ped, exists: ped ? DoesEntityExist(ped) : false, isLocalPlayer: ped === PlayerPedId() });
+
+    if (!ped || !DoesEntityExist(ped) || ped === PlayerPedId()) {
+      return;
+    }
+
+    const lanternEntity = GetCurrentPedWeaponEntityIndex(ped, value.attachPoint);
+    // console.log('[lantern-light] resolved lanternEntity', lanternEntity);
+    if (!lanternEntity) {
+      return;
+    }
+
+    const { oilColor } = value;
+    SetLightsColorForEntity(lanternEntity, oilColor[0], oilColor[1], oilColor[2]);
+    // console.log('[lantern-light] applied color to other ped lantern');
+  });
+}

--- a/resources/[core]/customization/src/client/managers/component-manager.ts
+++ b/resources/[core]/customization/src/client/managers/component-manager.ts
@@ -1,4 +1,4 @@
-import { PVGame } from '@lib/client';
+import { PVGame, setLanternOilColor } from '@lib/client';
 import { AttachPoint } from '@lib/flags';
 import { Delay } from '@lib/functions';
 import { BODY_CATEGORIES } from '@lib/shared/body-categories';
@@ -203,7 +203,7 @@ class ComponentManager {
             }
           }
           if (weaponEntity) {
-            SetLightsColorForEntity(weaponEntity, oilColor[0], oilColor[1], oilColor[2]);
+            setLanternOilColor(playerPed, AttachPoint.TempLantern, oilColor);
           }
         }
       }

--- a/resources/inventory/src/client/client.ts
+++ b/resources/inventory/src/client/client.ts
@@ -1,7 +1,9 @@
-import { PVCustomization, PVGame, emitUI, onUI } from '@lib/client';
+import { PVCustomization, PVGame, emitUI, initLanternLightSync, onUI } from '@lib/client';
 import { Delay } from '@lib/functions';
 import InventoryTypes from '@lib/shared/inventory-types';
 import PVItems from '@lib/shared/items';
+
+initLanternLightSync();
 
 import './events';
 import './exports';

--- a/resources/inventory/src/client/lantern-oil.ts
+++ b/resources/inventory/src/client/lantern-oil.ts
@@ -1,4 +1,4 @@
-import { PVGame } from '@lib/client';
+import { PVGame, setLanternOilColor } from '@lib/client';
 import { emitSocket } from '@lib/client/comms/ui';
 import { AttachPoint } from '@lib/flags';
 import PVItems from '@lib/shared/items';
@@ -34,11 +34,7 @@ on('inventory:client:apply_lantern_oil', (oilItem: Inventory.ItemLanternOil, oil
     return;
   }
 
-  const lanternEntity = GetCurrentPedWeaponEntityIndex(playerPed, attachPoint);
-  if (lanternEntity) {
-    const [red, green, blue] = oilItem.oilColor;
-    SetLightsColorForEntity(lanternEntity, red, green, blue);
-  }
+  setLanternOilColor(playerPed, attachPoint, oilItem.oilColor);
 
   const oilItemId = oilItemData.ids[0];
   emitSocket('inventory.apply-lantern-oil', oilItemId, lanternIdentifier);

--- a/resources/inventory/src/client/weapons.ts
+++ b/resources/inventory/src/client/weapons.ts
@@ -99,7 +99,7 @@
 //         end
 //     end
 // end)
-import { PVGame } from '@lib/client';
+import { PVGame, setLanternOilColor } from '@lib/client';
 import { AttachPoint } from '@lib/flags';
 import { Delay } from '@lib/functions';
 
@@ -167,7 +167,7 @@ on('inventory:client:toggle_weapon', async (item: Inventory.ItemWeapon, itemData
         await Delay(100);
       }
       if (weaponEntity) {
-        SetLightsColorForEntity(weaponEntity, oilColor[0], oilColor[1], oilColor[2]);
+        setLanternOilColor(playerPed, AttachPoint.MainHand, oilColor);
       }
     }
   }


### PR DESCRIPTION
The `SetLightsColorForEntity()` native is a client side non-networked call, as such the emissive light color being changed by inventory lantern oils is not reflected across all connected clients.

Annoyingly, the lantern "weapon" which a player is holding isn't a networked entity by itself - only the player is.

To resolve this, we add a state bag handler for the players ped entity, then attempt to get the equipped ped weapon entity via the attachment index.