### PR TITLE
Blip Manager Improvements 

### DIFF
--- a/resources/[features]/carrier-birds/src/client/debug-flight.ts
+++ b/resources/[features]/carrier-birds/src/client/debug-flight.ts
@@ -1,11 +1,11 @@
 import { PVBase } from '@lib/client';
+import { Vector3 } from '@lib/math';
 import BirdTypes from '@lib/shared/bird-types';
 import { BlipModifiers, BlipSprites, BlipStyles } from '@lib/shared/blips';
 
 const BLIP_ID = 'debug-bird-flight';
 
 interface FlightSim {
-  blipId: number;
   originX: number;
   originY: number;
   originZ: number;
@@ -77,19 +77,16 @@ RegisterCommand(
 
     const totalDistance = Math.max(calculate2DDistance(originX, originY, finalDestX, finalDestY), 200);
 
-    const blipId = PVBase.blipRegister(
-      BLIP_ID,
-      {
-        label: `${birdType} (debug flight)`,
-        sprite: BlipSprites.MISSION_BG,
-        modifiers: [BlipModifiers.LIGHT_BLUE],
-        coords: { x: originX, y: originY, z: originZ },
-      },
-      BlipStyles.FRIENDLY,
-    );
+    PVBase.blipRegister(BLIP_ID, {
+      type: 'sprite',
+      label: `${birdType} (debug flight)`,
+      sprite: BlipSprites.MISSION_BG,
+      modifiers: [BlipModifiers.LIGHT_BLUE],
+      coords: { x: originX, y: originY, z: originZ },
+      style: BlipStyles.FRIENDLY,
+    });
 
     activeSim = {
-      blipId,
       originX,
       originY,
       originZ,
@@ -133,7 +130,7 @@ setTick(() => {
   const currentY = lerp(activeSim.originY, activeSim.destY, progress);
   const currentZ = lerp(activeSim.originZ, activeSim.destZ, progress);
 
-  SetBlipCoords(activeSim.blipId, currentX, currentY, currentZ);
+  PVBase.blipUpdateCoords(BLIP_ID, Vector3.fromArray([currentX, currentY, currentZ]));
 
   if (progress >= 1) {
     console.log(`[BirdFlight] Arrived! Total time: ${(activeSim.distanceCovered / activeSim.speed).toFixed(1)}s`);

--- a/resources/[system]/rdr3-shared/types/index.d.ts
+++ b/resources/[system]/rdr3-shared/types/index.d.ts
@@ -119,6 +119,7 @@ declare function AddStateBagChangeHandler(keyFilter: string, bagFilter: string, 
 declare function GetPlayerFromStateBagName(bagName: string): number;
 declare function GetEntityFromStateBagName(bagName: string): number;
 declare function GetCurrentResourceName(): string;
+declare function GetInvokingResource(): string;
 declare function LoadResourceFile(resourceName: string, fileName: string): string;
 declare function GetRegisteredCommands(): any;
 declare function GetResourceByFindIndex(findIndex: number): string;

--- a/resources/[system]/rdr3-shared/types/natives/ITEMSET.d.ts
+++ b/resources/[system]/rdr3-shared/types/natives/ITEMSET.d.ts
@@ -38,7 +38,7 @@ declare function DestroyItemset(itemset: ItemSet): void;
    * @param {number} itemset
    * @return {number}
    */
-declare function GetIndexedItemInItemset(index: number, itemset: ItemSet): ScrHandle;
+declare function GetIndexedItemInItemset(index: number, itemset: ItemSet): number;
 
 /**
    * GET_INDEXED_SCENARIO_POINT_INDEX_IN_ITEMSET

--- a/resources/[system]/rdr3-shared/types/natives/MAP.d.ts
+++ b/resources/[system]/rdr3-shared/types/natives/MAP.d.ts
@@ -197,11 +197,10 @@ declare function LockMinimapAngle(angle: number): void;
 
 /**
    * REMOVE_BLIP
-   *
-  
+   * @param {number} blip
    * @return {number}
    */
-declare function RemoveBlip(): Blip;
+declare function RemoveBlip(blip: number): Blip;
 
 /**
    * RESET_MINIMAP_FOW

--- a/resources/[tools]/research/src/client/stuff/police.ts
+++ b/resources/[tools]/research/src/client/stuff/police.ts
@@ -1,7 +1,6 @@
 import {
   PVBase,
   PVGame,
-  PVGameEvents,
   PVJobs,
   PVKeymapper,
   PVTarget,
@@ -9,11 +8,9 @@ import {
   type PedReactionConfig,
   onResourceStop,
 } from '@lib/client';
-import { AnimFlag, AttachPoint, PedConfigFlag } from '@lib/flags';
-import { EntityProofs } from '@lib/flags/entity-proofs';
+import { AnimFlag, AttachPoint } from '@lib/flags';
 import { Delay } from '@lib/functions';
 import { Vector3 } from '@lib/math';
-import { BlipModifiers, BlipStyles, Sonars } from '@lib/shared/blips';
 
 let isWhistling = false;
 
@@ -85,6 +82,7 @@ PVTarget.AddTarget({
       label: 'Clock Out',
       icon: 'clock',
       event: 'jobs:client:clock-out',
+      parameters: { jobHandle: 'sheriff' },
       isEnabled() {
         return PVJobs.isCurrentlyClocked();
       },

--- a/resources/base/src/client/blip-setup.ts
+++ b/resources/base/src/client/blip-setup.ts
@@ -4,6 +4,6 @@ import Blips from './data/blips';
 setTimeout(() => {
   let b = 0;
   for (const blip of Blips) {
-    blipController.register(`base:${b++}`, blip);
+    blipController.register(`base:${b++}`, GetCurrentResourceName(), blip);
   }
 }, 5e3);

--- a/resources/base/src/client/controllers/blip-controller.ts
+++ b/resources/base/src/client/controllers/blip-controller.ts
@@ -1,9 +1,8 @@
-import { BlipStyles } from '@lib/shared/blips';
-
 export class BlipController {
   protected static instance: BlipController;
 
-  protected blips: Map<string, Base.BlipData> = new Map();
+  protected blips: Map<string, Base.InternalBlips> = new Map();
+  protected jobsClocked: Record<string, boolean> = {};
 
   static getInstance(): BlipController {
     if (!BlipController.instance) {
@@ -12,49 +11,93 @@ export class BlipController {
     return BlipController.instance;
   }
 
-  initialized = false;
-
   constructor() {
     on('onResourceStop', (resourceName: string) => {
       if (resourceName === GetCurrentResourceName()) {
         this.destruct();
+      } else {
+        this.resourceStopped(resourceName);
       }
     });
+
+    on('jobs:client:clock-in', (_: any, data: { jobHandle: string }) => {
+      this.jobsClocked[data.jobHandle] = true;
+      this.refreshBlips();
+    });
+    on('jobs:client:clock-out', (_: any, data: { jobHandle: string }) => {
+      delete this.jobsClocked[data.jobHandle];
+      this.refreshBlips();
+    });
+
+    emit('blip-controller.ready');
   }
 
-  destruct(): void {
+  private destruct(): void {
     for (const [id, data] of this.blips.entries()) {
-      Citizen.invokeNative('0x01B928CA2E198B01', data.id);
-      RemoveBlip(data.id);
-      this.blips.delete(id);
+      if (data.handle && DoesBlipExist(data.handle)) {
+        this.removeBlip(id);
+        this.blips.delete(id);
+      }
     }
   }
 
-  register(id: string, data: Base.BlipDataWithoutId, style = BlipStyles.NEUTRAL_OBJECTIVE) {
-    console.log('BlipController::register', id, data);
-    if (this.blips.has(id)) {
-      console.log(`Blip with id ${id} already exists, unregistering before registering new one.`);
-      this.unregister(id);
+  private resourceStopped(resourceName: string) {
+    for (const [id, data] of this.blips.entries()) {
+      if (data.resource === resourceName) {
+        this.removeBlip(id);
+        this.blips.delete(id);
+      }
     }
 
-    let blipId: number;
+    if (resourceName === 'jobs') {
+      this.jobsClocked = {};
+      this.refreshBlips();
+    }
+  }
+
+  private removeBlip(id: string) {
+    const blip = this.blips.get(id);
+    if (!blip || !blip.handle) return;
+
+    Citizen.invokeNative('0x01B928CA2E198B01', blip.handle); // I don't know what this native does, but I will keep it here.
+    RemoveBlip(blip.handle);
+    this.blips.set(id, { ...blip, handle: undefined });
+  }
+
+  private refreshBlips() {
+    for (const [id, data] of this.blips.entries()) {
+      let passedAllConstraints = true;
+
+      if (data.constraints.jobHandle && !this.jobsClocked[data.constraints.jobHandle]) {
+        passedAllConstraints = false;
+      }
+
+      if (passedAllConstraints && (!data.handle || !DoesBlipExist(data.handle))) {
+        this.drawBlip(id, data);
+      } else if (!passedAllConstraints && data.handle) {
+        this.removeBlip(id);
+      }
+    }
+  }
+
+  private drawBlip(id: string, data: Base.InternalBlips): Base.BlipData['handle'] {
+    let blipHandle: number;
     switch (data.type) {
       case 'sprite':
-        blipId = BlipAddForCoords(style, data.coords.x, data.coords.y, data.coords.z);
-        SetBlipSprite(blipId, data.sprite, true);
+        blipHandle = BlipAddForCoords(data.style, data.coords.x, data.coords.y, data.coords.z);
         break;
       case 'entity':
-        blipId = BlipAddForEntity(style, data.entity);
+        blipHandle = BlipAddForEntity(data.style, data.entity);
         break;
       case 'pickup':
-        blipId = BlipAddForPickupPlacement(style, data.pickup);
+        blipHandle = BlipAddForPickupPlacement(data.style, data.pickup);
         break;
       case 'radius':
-        blipId = BlipAddForRadius(style, data.coords.x, data.coords.y, data.coords.z, data.scale);
+        blipHandle = BlipAddForRadius(data.style, data.coords.x, data.coords.y, data.coords.z, data.scale);
         break;
       case 'area':
-        blipId = BlipAddForArea(
-          style,
+        blipHandle = BlipAddForArea(
+          data.style,
           data.coords.x,
           data.coords.y,
           data.coords.z,
@@ -65,39 +108,124 @@ export class BlipController {
         );
         break;
       case 'volume':
-        blipId = BlipAddForVolume(style, data.volume);
+        blipHandle = BlipAddForVolume(data.style, data.volume);
         break;
+      default: {
+        console.log('Blip Manager received a blip without a proper type. Aborting blip creation.');
+        return;
+      }
     }
     if ('sprite' in data && data.sprite) {
-      SetBlipSprite(blipId, data.sprite, true);
-    } else if ('style' in data) {
-      SetBlipSprite(blipId, data.style, true);
+      SetBlipSprite(blipHandle, data.sprite, true);
     }
     if (data.modifiers) {
       for (const modifier of data.modifiers) {
-        BlipAddModifier(blipId, modifier);
+        BlipAddModifier(blipHandle, modifier);
       }
     }
 
-    SetBlipFlashTimer(blipId, 16, -1);
-
-    const [_, blipType, mapCardId] = SetBlipFlashes(0);
-    // will return whatever you passed in blipType as long is an int
-
-    SetBlipName(blipId, data.label);
-    // console.log('Registering blip with id', id, blipId);
-    this.blips.set(id, { id: blipId, ...data });
-    return blipId;
+    SetBlipFlashTimer(blipHandle, 16, -1);
+    SetBlipFlashes(0);
+    SetBlipName(blipHandle, data.label);
+    this.blips.set(id, { ...data, handle: blipHandle });
   }
 
-  unregister(id: string) {
-    const blipData = this.blips.get(id);
-    if (!blipData) {
+  public register(
+    id: string,
+    resource: string,
+    data: Base.BlipDataWithoutIdAndResource,
+    constraints: Base.BlipConstraints = {},
+  ) {
+    console.log('BlipController::register', id, resource, data);
+
+    const blip = this.blips.get(id);
+
+    if (blip) {
+      this.removeBlip(id);
+    }
+
+    this.blips.set(id, { ...data, resource, constraints, id });
+
+    this.refreshBlips();
+  }
+
+  public updateCoords(blipId: string, coords: Vector3Format) {
+    const blip = this.blips.get(blipId);
+
+    if (!blip || !('coords' in blip)) return;
+
+    if (blip.handle && DoesBlipExist(blip.handle)) {
+      SetBlipCoords(blip.handle, coords.x, coords.y, coords.z);
+    }
+
+    this.blips.set(blipId, { ...blip, coords });
+  }
+
+  public updateSprite(blipId: string, sprite: number) {
+    const blip = this.blips.get(blipId);
+
+    if (!blip || !('sprite' in blip)) return;
+
+    if (blip.handle && DoesBlipExist(blip.handle)) {
+      SetBlipSprite(blip.handle, sprite, true);
+    }
+
+    this.blips.set(blipId, { ...blip, sprite });
+  }
+
+  public updateLabel(blipId: string, label: string) {
+    const blip = this.blips.get(blipId);
+
+    if (!blip || !('label' in blip)) return;
+
+    if (blip.handle && DoesBlipExist(blip.handle)) {
+      SetBlipName(blip.handle, label);
+    }
+
+    this.blips.set(blipId, { ...blip, label });
+  }
+
+  public addModifier(id: string, modifier: number) {
+    const blip = this.blips.get(id);
+
+    if (!blip) return;
+
+    if (blip.handle && DoesBlipExist(blip.handle)) {
+      BlipAddModifier(blip.handle, modifier);
+    }
+
+    const newModifiers = blip.modifiers ? [...blip.modifiers, modifier] : [modifier];
+    this.blips.set(id, { ...blip, modifiers: newModifiers });
+  }
+
+  public removeModifier(id: string, modifier: number = 0) {
+    const blip = this.blips.get(id);
+
+    if (!blip) return;
+
+    if (blip.handle && DoesBlipExist(blip.handle)) {
+      BlipRemoveModifier(blip.handle, modifier);
+    }
+
+    const newModifiers = modifier === 0 ? [] : blip.modifiers?.filter((mod) => mod === modifier);
+
+    this.blips.set(id, { ...blip, modifiers: newModifiers });
+  }
+
+  public getHandle(id: string): Base.BlipData['handle'] {
+    const blip = this.blips.get(id);
+    if (blip) {
+      return blip.handle;
+    }
+  }
+
+  public unregister(id: string) {
+    const blip = this.blips.get(id);
+    if (!blip) {
       return;
     }
-    console.log('Unregistering blip with id', id, blipData.id);
-    Citizen.invokeNative('0x01B928CA2E198B01', blipData.id);
-    RemoveBlip(blipData.id);
+    console.log('Unregistering blip with id', id, blip.handle);
+    this.removeBlip(id);
     this.blips.delete(id);
   }
 }

--- a/resources/base/src/client/controllers/blip-controller.ts
+++ b/resources/base/src/client/controllers/blip-controller.ts
@@ -212,7 +212,7 @@ export class BlipController {
     this.blips.set(id, { ...blip, modifiers: newModifiers });
   }
 
-  public getHandle(id: string): Base.BlipData['handle'] {
+  public getHandle(id: string) {
     const blip = this.blips.get(id);
     if (blip) {
       return blip.handle;

--- a/resources/base/src/client/data/blips.ts
+++ b/resources/base/src/client/data/blips.ts
@@ -1,49 +1,56 @@
-import { BlipModifiers, BlipSprites } from '@lib/shared/blips';
+import { BlipModifiers, BlipSprites, BlipStyles } from '@lib/shared/blips';
 import PostOffices from '@lib/shared/post-offices';
 
-const postOfficeBlips: Base.BlipDataWithoutId[] = PostOffices.map((po) => ({
+const postOfficeBlips: Base.BlipDataWithoutIdAndResource[] = PostOffices.map((po) => ({
   label: 'Post Office',
   type: 'sprite',
   sprite: BlipSprites.POST_OFFICE,
   coords: po.coords,
+  style: BlipStyles.NEUTRAL,
 }));
 
-const Blips: Omit<Base.BlipData, 'id'>[] = [
+const Blips: Base.BlipDataWithoutIdAndResource[] = [
   /**
    * Valentine
    */
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Butcher',
     sprite: BlipSprites.SHOP_BUTCHER,
     coords: { x: -338.99, y: 767.6321, z: 115.5632 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: -175.2594, y: 631.9643, z: 113.0896 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Bath',
     sprite: BlipSprites.BATH_HOUSE,
     coords: { x: -317.424, y: 762.619, z: 117.436 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'General Store',
     sprite: BlipSprites.SHOP_STORE,
     coords: { x: -324.0513, y: 803.7102, z: 116.8817 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Gunsmith',
     sprite: BlipSprites.SHOP_GUNSMITH,
     coords: { x: -281.0177, y: 778.9867, z: 118.504 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -51,6 +58,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -58,6 +66,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Barber',
     sprite: BlipSprites.SHOP_BARBER,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -65,6 +74,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Tailor',
     sprite: BlipSprites.SHOP_TAILOR,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -72,6 +82,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Bank',
     sprite: BlipSprites.PROC_BANK,
     modifiers: [BlipModifiers.GREEN],
@@ -79,12 +90,14 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -368.7, y: 786.9, z: 116.2 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Doctor',
     sprite: BlipSprites.SHOP_DOCTOR,
     modifiers: [BlipModifiers.TEAL],
@@ -94,24 +107,28 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   // -=================
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Butcher',
     sprite: BlipSprites.SHOP_BUTCHER,
     coords: { x: 2540.75, y: 802.25, z: 76.37 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Butcher',
     sprite: BlipSprites.SHOP_BUTCHER,
     coords: { x: -1752.9288, y: -392.7518, z: 155.2471 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Butcher',
     sprite: BlipSprites.SHOP_BUTCHER,
     coords: { x: -753.337, y: -1284.7538, z: 42.5011 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Bank',
     sprite: BlipSprites.PROC_BANK,
     modifiers: [BlipModifiers.GREEN],
@@ -119,18 +136,21 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Butcher',
     sprite: BlipSprites.SHOP_BUTCHER,
     coords: { x: -5510.3481, y: -2946.9421, z: -2.8951 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Butcher',
     sprite: BlipSprites.SHOP_BUTCHER,
     coords: { x: 2819.4917, y: -1331.3773, z: 45.5076 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Bank',
     sprite: BlipSprites.PROC_BANK,
     modifiers: [BlipModifiers.GREEN],
@@ -138,30 +158,35 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Gunsmith',
     sprite: BlipSprites.SHOP_GUNSMITH,
     coords: { x: 2946.45, y: 1319.47, z: 44.82 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: -732.5, y: -1226.7, z: 44.8 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: 1230.3, y: -1298.7, z: 76.0 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: -3729.1, y: -2601.4, z: -13.9 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     // Annesburg
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
@@ -169,6 +194,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     // Annesburg
     label: 'Bath',
     sprite: BlipSprites.BATH_HOUSE,
@@ -176,6 +202,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     // Rhodes
     label: 'Bath',
     sprite: BlipSprites.BATH_HOUSE,
@@ -183,6 +210,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     // St.Denis
     label: 'Bath',
     sprite: BlipSprites.BATH_HOUSE,
@@ -190,6 +218,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Bank',
     sprite: BlipSprites.PROC_BANK,
     modifiers: [BlipModifiers.GREEN],
@@ -197,6 +226,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Bank',
     sprite: BlipSprites.PROC_BANK,
     modifiers: [BlipModifiers.GREEN],
@@ -204,6 +234,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -211,6 +242,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -218,6 +250,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -225,6 +258,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -232,6 +266,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -239,6 +274,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -246,6 +282,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -253,6 +290,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Saloon',
     sprite: BlipSprites.SALOON,
     modifiers: [BlipModifiers.TAN],
@@ -260,90 +298,105 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -866.5, y: -1366.9, z: 43.5 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -1819.4, y: -561.9, z: 156.1 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: 1209.2, y: -192.9, z: 101.4 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: 2503.2, y: -1451.8, z: 46.3 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: 2968.7, y: 796.4, z: 51.4 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -5520.9, y: -3044.5, z: -2.4 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: 1434.199, y: -1294.95, z: 77.823 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -1338.55, y: 2399.3, z: 306.985 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -2217.875, y: 733.65, z: 123.08 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -2407.496, y: -2376.35, z: 61.176 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -1415.363, y: -2197.88, z: 43.395 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -629.495, y: -64.463, z: 82.933 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -861.817, y: 336.34, z: 96.424 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Stables',
     sprite: BlipSprites.STABLE,
     coords: { x: -3709.043, y: -2553.437, z: -14.64 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Barber',
     sprite: BlipSprites.SHOP_BARBER,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -351,6 +404,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Tailor',
     sprite: BlipSprites.SHOP_TAILOR,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -358,6 +412,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Barber',
     sprite: BlipSprites.SHOP_BARBER,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -365,6 +420,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Tailor',
     sprite: BlipSprites.SHOP_TAILOR,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -372,6 +428,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Tailor',
     sprite: BlipSprites.SHOP_TAILOR,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -379,6 +436,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Tailor',
     sprite: BlipSprites.SHOP_TAILOR,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -386,6 +444,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Tailor',
     sprite: BlipSprites.SHOP_TAILOR,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -393,6 +452,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Tailor',
     sprite: BlipSprites.SHOP_TAILOR,
     modifiers: [BlipModifiers.OFF_WHITE],
@@ -400,12 +460,14 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Sheriff',
     sprite: BlipSprites.AMB_SHERIFF,
     coords: { x: 2907.331, y: 1311.787, z: 44.938 },
   },
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Poker',
     sprite: BlipSprites.MG_POKER,
     coords: { x: 2718.1831, y: -1288.4312, z: 60.36 },
@@ -413,6 +475,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   // St Dennis
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: 2747.800537, y: -1396.466431, z: 46.183098 },
@@ -420,6 +483,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   // Wallace Station
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: -1300.310913, y: 400.040833, z: 95.452156 },
@@ -427,6 +491,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   // <editor-fold desc="Riggs Station">
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: -1094.323608, y: -577.707947, z: 82.409836 },
@@ -436,6 +501,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   // <editor-fold desc="Emerald Station">
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: 1523.589111, y: 442.681946, z: 90.67852 },
@@ -445,6 +511,7 @@ const Blips: Omit<Base.BlipData, 'id'>[] = [
   // <editor-fold desc="Benedict Point">
   {
     type: 'sprite',
+    style: BlipStyles.NEUTRAL,
     label: 'Train Station',
     sprite: BlipSprites.SHOP_TRAIN,
     coords: { x: -5228.602051, y: -3468.348145, z: -20.569672 },

--- a/resources/base/src/client/exports.ts
+++ b/resources/base/src/client/exports.ts
@@ -1,7 +1,6 @@
 import { exports } from '@lib/client';
 import { onUI } from '@lib/client/comms/ui';
 import { Delay } from '@lib/functions';
-import { BlipStyles } from '@lib/shared/blips';
 
 import blipController from './controllers/blip-controller';
 
@@ -105,12 +104,36 @@ const deleteEntities: Base.deleteEntities = (entities: number[], attached = fals
   }
 };
 
-const blipRegister: Base.blipRegister = (id, data, style = BlipStyles.NEUTRAL_OBJECTIVE) => {
-  return blipController.register(id, data, style);
+const blipRegister: Base.blipRegister = (id, data, constraints) => {
+  return blipController.register(id, GetInvokingResource(), data, constraints);
 };
 
 const blipUnregister: Base.blipUnregister = (id) => {
   blipController.unregister(id);
+};
+
+const blipUpdateCoords: Base.blipUpdateCoords = (id, coords) => {
+  blipController.updateCoords(id, coords);
+};
+
+const blipUpdateSprite: Base.blipUpdateSprite = (id, sprite) => {
+  blipController.updateSprite(id, sprite);
+};
+
+const blipGetHandle: Base.blipGetHandle = (id) => {
+  return blipController.getHandle(id);
+};
+
+const blipUpdateLabel: Base.blipUpdateLabel = (id, label) => {
+  blipController.updateLabel(id, label);
+};
+
+const blipAddModifier: Base.blipAddModifier = (id: string, modifier: number) => {
+  blipController.addModifier(id, modifier);
+};
+
+const blipRemoveModifier: Base.blipRemoveModifier = (id: string, modifier: number) => {
+  blipController.removeModifier(id, modifier);
 };
 
 // Register all exports
@@ -119,4 +142,10 @@ exports<'base'>('getNetworkControlOfEntity', getNetworkControlOfEntity);
 exports<'base'>('deleteEntity', deleteEntity);
 exports<'base'>('deleteEntities', deleteEntities);
 exports<'base'>('blipRegister', blipRegister);
+exports<'base'>('blipGetHandle', blipGetHandle);
+exports<'base'>('blipUpdateCoords', blipUpdateCoords);
+exports<'base'>('blipUpdateSprite', blipUpdateSprite);
+exports<'base'>('blipUpdateLabel', blipUpdateLabel);
+exports<'base'>('blipAddModifier', blipAddModifier);
+exports<'base'>('blipRemoveModifier', blipRemoveModifier);
 exports<'base'>('blipUnregister', blipUnregister);

--- a/resources/base/src/client/types.d.ts
+++ b/resources/base/src/client/types.d.ts
@@ -6,31 +6,38 @@ declare namespace Base {
   type DoorData = [doorHash: number, modelHash: number, modelName: string, x: number, y: number, z: number];
   type BlipData =
     | {
-        id: number;
+        handle?: number;
+        resource: string;
         type: 'sprite';
         label: string;
         sprite: string | number;
         modifiers?: number[];
+        style: number;
         coords: Vector3Format;
       }
     | {
-        id: number;
+        handle?: number;
+        resource: string;
         type: 'entity';
         label: string;
         sprite: string | number;
         modifiers?: number[];
+        style: number;
         entity: number;
       }
     | {
-        id: number;
+        handle?: number;
+        resource: string;
         type: 'pickup';
         label: string;
         sprite: string | number;
         modifiers?: number[];
+        style: number;
         pickup: number;
       }
     | {
-        id: number;
+        handle?: number;
+        resource: string;
         type: 'radius';
         style: string | number;
         sprite?: string | number;
@@ -40,7 +47,8 @@ declare namespace Base {
         scale: number;
       }
     | {
-        id: number;
+        handle?: number;
+        resource: string;
         type: 'area';
         label: string;
         style: string | number;
@@ -50,7 +58,8 @@ declare namespace Base {
         scale: [number, number];
       }
     | {
-        id: number;
+        handle?: number;
+        resource: string;
         type: 'volume';
         label: string;
         style: string | number;
@@ -58,15 +67,31 @@ declare namespace Base {
         volume: number;
         modifiers?: number[];
       };
+
+  type BlipConstraints = {
+    jobHandle?: string;
+  };
+
   type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
 
-  type BlipDataWithoutId = DistributiveOmit<BlipData, 'id'>;
+  type InternalBlips = BlipData & {
+    constraints: BlipConstraints;
+    id: string;
+  };
+
+  type BlipDataWithoutIdAndResource = DistributiveOmit<DistributiveOmit<BlipData, 'handle'>, 'resource'>;
 
   type getNetworkControlOfEntity = (entity: number) => Promise<void>;
   type deleteEntity = (entity: number, attached?: boolean) => void;
   type deleteEntities = (entities: number[], attached?: boolean) => void;
 
-  type blipRegister = (id: string, data: BlipDataWithoutId, style?: number) => number;
+  type blipRegister = (id: string, data: BlipDataWithoutIdAndResource, constraints?: BlipConstraints) => void;
+  type blipGetHandle = (id: string) => void;
+  type blipUpdateCoords = (id: string, coords: Vector3Format) => void;
+  type blipUpdateSprite = (id: string, sprite: number) => void;
+  type blipUpdateLabel = (id: string, label: string) => void;
+  type blipAddModifier = (id: string, modifier: number) => void;
+  type blipRemoveModifier = (id: string, modifier: number) => void;
   type blipUnregister = (id: string) => void;
 
   type ClientExports = {
@@ -76,6 +101,12 @@ declare namespace Base {
     getCurrentCharacter: () => CharacterData | null;
     blipRegister: blipRegister;
     blipUnregister: blipUnregister;
+    blipUpdateCoords: blipUpdateCoords;
+    blipUpdateSprite: blipUpdateSprite;
+    blipUpdateLabel: blipUpdateLabel;
+    blipAddModifier: blipAddModifier;
+    blipRemoveModifier: blipRemoveModifier;
+    blipGetHandle: blipGetHandle;
   };
 }
 

--- a/resources/base/src/client/types.d.ts
+++ b/resources/base/src/client/types.d.ts
@@ -86,7 +86,7 @@ declare namespace Base {
   type deleteEntities = (entities: number[], attached?: boolean) => void;
 
   type blipRegister = (id: string, data: BlipDataWithoutIdAndResource, constraints?: BlipConstraints) => void;
-  type blipGetHandle = (id: string) => void;
+  type blipGetHandle = (id: string) => number | undefined;
   type blipUpdateCoords = (id: string, coords: Vector3Format) => void;
   type blipUpdateSprite = (id: string, sprite: number) => void;
   type blipUpdateLabel = (id: string, label: string) => void;

--- a/resources/stable/src/client/controllers/stable-controller.ts
+++ b/resources/stable/src/client/controllers/stable-controller.ts
@@ -1,9 +1,9 @@
-import { PVBase, PVCustomization, PVGame, PVInit, PVZone, onResourceInit } from '@lib/client';
+import { PVBase, PVCustomization, PVGame, PVInit, onResourceInit } from '@lib/client';
 import { awaitUI } from '@lib/client/comms/ui';
 import { PedConfigFlag } from '@lib/flags';
 import { Delay } from '@lib/functions';
 import { Vector3, lerp } from '@lib/math';
-import { BlipModifiers, BlipSprites } from '@lib/shared/blips';
+import { BlipModifiers, BlipSprites, BlipStyles } from '@lib/shared/blips';
 import { GetDays } from '@lib/shared/time';
 
 import HorseExpressions from '../../shared/data/horse-expressions';
@@ -65,7 +65,7 @@ class StableController {
         this.horseMakeNetworked(mount);
       }
     };
-    on('events_manager:mount', (onMount: number, horsePed: number, currentSeat: number) => {
+    on('events_manager:mount', (onMount: number, horsePed: number, _currentSeat: number) => {
       // console.log('events_manager:mount', onMount, horsePed, currentSeat);
       this.checkHorse(horsePed);
       if (onMount) {
@@ -132,10 +132,12 @@ class StableController {
           continue;
         }
         PVBase.blipRegister(`horse:${horseId}`, {
+          type: 'sprite',
           label: horse.name,
           sprite: BlipSprites.HORSE_OWNED,
           modifiers: [BlipModifiers.SCALE_2],
           coords: { x: horse.lastX, y: horse.lastY, z: horse.lastZ },
+          style: BlipStyles.NEUTRAL,
         });
         continue;
       }
@@ -152,7 +154,7 @@ class StableController {
         continue;
       }
 
-      const coords = GetEntityCoords(horsePed, true);
+      const coords = GetEntityCoords(horsePed, true, true);
       horse.lastX = coords[0];
       horse.lastY = coords[1];
       horse.lastZ = coords[2];
@@ -175,10 +177,12 @@ class StableController {
     for (const horse of this._horses.values()) {
       if (!horse.stable) {
         PVBase.blipRegister(`horse:${horse.id}`, {
+          type: 'sprite',
           label: horse.name,
           sprite: BlipSprites.HORSE_OWNED,
           modifiers: [BlipModifiers.SCALE_2],
           coords: { x: horse.lastX, y: horse.lastY, z: horse.lastZ },
+          style: BlipStyles.NEUTRAL,
         });
       }
     }
@@ -252,7 +256,7 @@ class StableController {
       duration: 500,
     });
     await Delay(500);
-    SetPedToRagdoll(foalPed, 1000, 3000, 0, false, false, false);
+    SetPedToRagdoll(foalPed, 1000, 3000, 0, false, false, 0);
 
     foalHorse.save();
     console.log('Foal born', foalHorse);
@@ -261,11 +265,7 @@ class StableController {
   canHorseSpawn(horseId: Horse.Id): boolean {
     const foalPregnancy = this._pregnancies.find((pregnancy) => pregnancy.foalId === horseId);
 
-    if (foalPregnancy && foalPregnancy.status !== 'BIRTHED') {
-      return false;
-    }
-
-    return true;
+    return !(foalPregnancy && foalPregnancy.status !== 'BIRTHED');
   }
 
   addStable(data: Stable.Data): void {


### PR DESCRIPTION
Blip manager will now manage the state of the resource from which the blip registration was requested. Meaning, when a resource that has registered a blip stops, the blip will get destroyed and deleted.

Blip manager also now has the ability to restrict blips shown based on which job the player is clocked in as.  

I've also changed the blips that where already implemented to conform with the new types and parameters.